### PR TITLE
Support guardduty agent to run in parallel with the fargate task

### DIFF
--- a/packages/steps-s3-copy/src/steps-s3-copy-construct.ts
+++ b/packages/steps-s3-copy/src/steps-s3-copy-construct.ts
@@ -412,16 +412,21 @@ export class StepsS3CopyConstruct extends Construct {
         new ServicePrincipal("ecs-tasks.amazonaws.com"),
         new ServicePrincipal("lambda.amazonaws.com"),
       ),
-      // Allow the task definition role ecr access to the guardduty agent
-      // https://docs.aws.amazon.com/guardduty/latest/ug/prereq-runtime-monitoring-ecs-support.html#before-enable-runtime-monitoring-ecs
-      // Which is in another account - 005257825471.dkr.ecr.ap-southeast-2.amazonaws.com/aws-guardduty-agent-fargate
-      managedPolicies: [ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonECSTaskExecutionRolePolicy')]
     });
 
     // the role is assigned to lambdas - so they need enough permissions to execute
     writerRole.addManagedPolicy(
       ManagedPolicy.fromAwsManagedPolicyName(
         "service-role/AWSLambdaBasicExecutionRole",
+      ),
+    );
+
+    // Allow the task definition role ecr access to the guardduty agent
+    // https://docs.aws.amazon.com/guardduty/latest/ug/prereq-runtime-monitoring-ecs-support.html#before-enable-runtime-monitoring-ecs
+    // Which is in another account - 005257825471.dkr.ecr.ap-southeast-2.amazonaws.com/aws-guardduty-agent-fargate
+      writerRole.addManagedPolicy(
+      ManagedPolicy.fromAwsManagedPolicyName(
+        "service-role/AmazonECSTaskExecutionRolePolicy",
       ),
     );
 

--- a/packages/steps-s3-copy/src/steps-s3-copy-construct.ts
+++ b/packages/steps-s3-copy/src/steps-s3-copy-construct.ts
@@ -412,6 +412,10 @@ export class StepsS3CopyConstruct extends Construct {
         new ServicePrincipal("ecs-tasks.amazonaws.com"),
         new ServicePrincipal("lambda.amazonaws.com"),
       ),
+      // Allow the task definition role ecr access to the guardduty agent
+      // https://docs.aws.amazon.com/guardduty/latest/ug/prereq-runtime-monitoring-ecs-support.html#before-enable-runtime-monitoring-ecs
+      // Which is in another account - 005257825471.dkr.ecr.ap-southeast-2.amazonaws.com/aws-guardduty-agent-fargate
+      managedPolicies: [ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonECSTaskExecutionRolePolicy')]
     });
 
     // the role is assigned to lambdas - so they need enough permissions to execute


### PR DESCRIPTION
See https://docs.aws.amazon.com/guardduty/latest/ug/prereq-runtime-monitoring-ecs-support.html#before-enable-runtime-monitoring-ecs for more information

Resolves #30 