### PR TITLE
ci: use corepack to install npm

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -37,9 +37,10 @@ jobs:
       - run: pnpm run package
 
       # if all the builds have completed - we can publish the package
-      # publib-npm needs newest NPM 11 to have trusted publisher mode
-
-      - run: npm install -g npm@next-11
+      # publib-npm needs newest NPM 11 to have trusted publisher mode.
+      # Currently node 22.22.2 has a broken npm, so use corepack directly.
+      - run: corepack enable npm
+      - run: corepack install -g npm@11
 
       - run: pnpm exec publib-npm
         working-directory: packages/steps-s3-copy


### PR DESCRIPTION
Node 22.2.2 has a broken npm installation, see https://github.com/actions/runner-images/issues/13883

### Changes
* Switch to corepack override.
* Also move from next-11 to just 11 as it's stable.