### PR TITLE
ci: set COREPACK_ENABLE_STRICT to allow global npm

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -47,3 +47,5 @@ jobs:
         env:
           NPM_TRUSTED_PUBLISHER: true
           NPM_ACCESS_LEVEL: public
+          # Required for global corepack npm installation
+          COREPACK_ENABLE_STRICT: 0


### PR DESCRIPTION
Related to #47 

This is required to allow the npm installation to work with corepack because of the "packageManager" field.