### PR TITLE
fix: pre-pack using npm before publish

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -41,6 +41,12 @@ jobs:
       - run: corepack enable npm
       - run: corepack install -g npm@11
 
+      # Bun has an issue with installing bundledDependencies without symlinks which
+      # breaks the published package, so a prepack script is required to ensure that
+      # package is properly bundled.
+      - run: npm install --omit=dev --no-package-lock --legacy-peer-deps --ignore-scripts --workspaces=false
+        working-directory: packages/steps-s3-copy
+
       - run: bunx publib-npm
         working-directory: packages/steps-s3-copy
         env:

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -44,7 +44,7 @@ jobs:
       # Bun has an issue with installing bundledDependencies without symlinks which
       # breaks the published package, so a prepack script is required to ensure that
       # package is properly bundled.
-      - run: npm install --omit=dev --no-package-lock --legacy-peer-deps --ignore-scripts --workspaces=false
+      - run: npm install --omit=dev --no-package-lock --ignore-scripts --workspaces=false
         working-directory: packages/steps-s3-copy
 
       - run: bunx publib-npm

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,0 @@
-[install]
-linker = "hoisted"


### PR DESCRIPTION
It looks like bun fails to properly pack the tarball when publishing with `bundledDependencies`. It doesn't appear to correctly resolve symlinks vs regular dependencies. This results in missing dependencies for the consuming package. I think this is an issue with bun itself, as it works for some packages, but not others (i.e. it works for scoped packages with @). 

Either way, adding an `npm install` before publishing to ensure that the package is bundled properly.