### PR TITLE
fix: need to remove --omit=dev

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -44,7 +44,7 @@ jobs:
       # Bun has an issue with installing bundledDependencies without symlinks which
       # breaks the published package, so a prepack script is required to ensure that
       # package is properly bundled.
-      - run: npm install --omit=dev --no-package-lock --ignore-scripts --workspaces=false
+      - run: npm install --no-package-lock --ignore-scripts --workspaces=false
         working-directory: packages/steps-s3-copy
 
       - run: bunx publib-npm


### PR DESCRIPTION
Related to #50 

--omit=dev has to be removed otherwise jsii and other dependencies will fail to install for the publib-npm step