### PR TITLE
fix: node_modules results in endless .. warning

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -44,7 +44,7 @@ jobs:
       # Bun has an issue with installing bundledDependencies without symlinks which
       # breaks the published package, so a prepack script is required to ensure that
       # package is properly bundled.
-      - run: npm install --no-package-lock --ignore-scripts --workspaces=false
+      - run: rm -rf node_modules && npm install --no-package-lock --ignore-scripts --workspaces=false
         working-directory: packages/steps-s3-copy
 
       - run: bunx publib-npm


### PR DESCRIPTION
Related to #50 

The node_modules also needs to be cleaned before running an install otherwise there are packaging errors.