### PR TITLE
feat: add retainCopyCsv and summarise copy output

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -38,7 +38,6 @@ jobs:
       - run: corepack enable npm
       - run: corepack install -g npm@11
 
-
       # Bun has an issue with installing bundledDependencies without symlinks which
       # breaks the published package, so a prepack script is required to ensure that
       # package is properly bundled.

--- a/README.md
+++ b/README.md
@@ -151,10 +151,18 @@ export type StepsS3CopyInvokeArguments = {
   readonly destinationRequiredRegion?: string;
 
   /**
-   * The relative path (relative to `workingBucketPrefixKey`) to the copy-instructions input file.
-   * This file is JSONL: one `CopyInstruction` per line.
+   * The slash-terminated folder (relative to `workingBucketPrefixKey`) that contains the
+   * copy-instructions JSONL input file. This directory is expected to contain a JSONL file
+   * with the name of `copyInstructionsFileName`. Use `""` to place it at the root of
+   * `workingBucketPrefixKey`.
    */
-  readonly copyInstructionsKey: string;
+  readonly copyInstructionsFolder: string;
+
+  /**
+   * The name of the JSONL copy-instructions file inside `copyInstructionsFolder`. Defaults
+   * to `INSTRUCTIONS.jsonl` if not specified.
+   */
+  readonly copyInstructionsFileName?: string;
 
   /**
    * The destination bucket to copy the objects.
@@ -170,8 +178,23 @@ export type StepsS3CopyInvokeArguments = {
   readonly copyConcurrency: number;
   readonly maxItemsPerBatch: number;
 
-  readonly destinationStartCopyRelativeKey: string;
-  readonly destinationEndCopyRelativeKey: string;
+  /**
+   * Relative key (under `destinationFolderKey`) of the start-of-copy marker object.
+   * Defaults to `STARTED_COPY.txt` if omitted.
+   */
+  readonly destinationStartCopyRelativeKey?: string;
+
+  /**
+   * Relative key (under `destinationFolderKey`) of the start copy marker. Defaults to `STARTED_COPY.txt`
+   * if omitted.
+   */
+  readonly destinationEndCopyRelativeKey?: string;
+
+  /**
+   * Relative key (under `destinationFolderKey`) of the end copy CSV once the copy completes. Defaults
+   * to `ENDED_COPY.csv` if omitted.
+   */
+  readonly destinationEndCopyReportRelativeKey?: string;
 
   /**
    * If present and true, instructs the copier to go through the motions of
@@ -181,13 +204,16 @@ export type StepsS3CopyInvokeArguments = {
   readonly dryRun?: boolean;
 
   /**
-   * If present and true, generate html copy report (COPY_REPORT.html)  in the destination.
+   * If present and true, generate the HTML copy report in the destination
+   * (named by `destinationEndCopyReportRelativeKey`).
    * If omitted, defaults to false.
    */
   readonly includeCopyReport?: boolean;
 
   /**
-   * If set, also save a copy report (COPY_REPORT.html) in the same bucket and prefix as the source file.
+   * If set, also save a copy of the HTML report (named by the basename of
+   * `destinationEndCopyReportRelativeKey`) in the working bucket alongside the copy
+   * instructions file.
    */
   readonly retainCopyReport?: boolean;
 
@@ -250,7 +276,100 @@ type BucketDefinition = {
 };
 ```
 
-Note that the `copyInstructionsKey` points to the JSONL copy-instructions file (relative to the working folder). For instance if we uploaded the JSONL copy instructions to `s3://my-working-bucket/a-working-folder/instructions.jsonl`, we would specify a `copyInstructionsKey` of `instructions.jsonl`.
+`copyInstructionsFolder` points to the slash-terminated folder (relative to the working folder) that
+holds the JSONL copy-instructions file, and `copyInstructionsFileName` names the file itself.
+For instance, if we uploaded the JSONL copy instructions to
+`s3://my-working-bucket/a-working-folder/job/INSTRUCTIONS.jsonl`, we would specify
+`copyInstructionsFolder` of `job/` and leave `copyInstructionsFileName` unset (or set it to
+`INSTRUCTIONS.jsonl`).
+
+Outputs of the copy run also land in this same folder, e.g. CSV/HTML reports if
+`retainCopyCsv`/`retainCopyReport` are set, and the distributed-map result manifests.
+
+Note, it is expected that `copyInstructionsFolder` represents a single copy invocation. A new copy
+should have a different `copyInstructionsFolder`. If it is re-used, the reports and output files will be
+overwritten.
+
+### File structure in the working and destination buckets
+
+Two buckets are involved in any copy run:
+
+- The **working bucket** (set at deploy time via `workingBucket` + `workingBucketPrefixKey`) holds
+  the JSONL copy-instructions, the per-map result manifests, and any retained copies of the
+  CSV summary and HTML report.
+- The **destination bucket** (set per invocation via `destinationBucket` + `destinationFolderKey`)
+  receives the copied objects, the start copy marker, the CSV summary, and optionally the HTML report.
+
+The `workingBucketPrefixKey`, `copyInstructionsFolder`, and `destinationFolderKey` inputs must be either an empty string `""`
+or end with a slash.
+
+#### Where each file lands
+
+The below table summarises each output:
+
+| Artifact                         | Bucket      | Key                                                                                                                                                            | Controlled by                                                |
+| -------------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Copy instructions JSONL          | working     | `<workingBucketPrefixKey><copyInstructionsFolder><copyInstructionsFileName>`                                                                                   | uploaded by caller before invocation                         |
+| Distributed map result manifests | working     | `<workingBucketPrefixKey><copyInstructionsFolder><MapRunArn>/manifest.json` and `<workingBucketPrefixKey><copyInstructionsFolder><MapRunArn>/SUCCEEDED_*.json` | HeadObjects, Small, Large, NeedThawSmall, NeedThawLarge maps |
+| Copy set JSONL files             | working     | `<workingBucketPrefixKey><copyInstructionsFolder><HeadObjectsMapRunArn>/{small,large,smallThaw,largeThaw}.jsonl`                                               | CoordinateCopy lambda                                        |
+| Retained CSV summary             | working     | `<workingBucketPrefixKey><copyInstructionsFolder><basename(destinationEndCopyRelativeKey)>`                                                                    | `retainCopyCsv: true`                                        |
+| Retained HTML report             | working     | `<workingBucketPrefixKey><copyInstructionsFolder><basename(destinationEndCopyReportRelativeKey)>`                                                              | `retainCopyReport: true`                                     |
+| Start copy marker                | destination | `<destinationFolderKey><destinationStartCopyRelativeKey>`                                                                                                      | CanWrite lambda                                              |
+| End copy CSV                     | destination | `<destinationFolderKey><destinationEndCopyRelativeKey>`                                                                                                        | SummariseCopy lambda                                         |
+| HTML report                      | destination | `<destinationFolderKey><destinationEndCopyReportRelativeKey>`                                                                                                  | `includeCopyReport: true`                                    |
+| Copied objects                   | destination | `<destinationFolderKey><destinationKey>`                                                                                                                       | per copy-instruction                                         |
+
+For example, take the following settings to see how files would be laid out.
+
+Construct props:
+
+```typescript
+new StepsS3CopyConstruct(this, "Copy", {
+  vpc,
+  vpcSubnetSelection: SubnetType.PRIVATE_WITH_EGRESS,
+  workingBucket: "my-working-bucket",
+  workingBucketPrefixKey: "copy-out/",
+});
+```
+
+Invoke args:
+
+```json
+{
+  "copyInstructionsFolder": "job-a/",
+  "destinationBucket": "destination",
+  "destinationFolderKey": "datasets/release/",
+  "includeCopyReport": true,
+  "retainCopyReport": true,
+  "retainCopyCsv": true,
+  "copyConcurrency": 80,
+  "maxItemsPerBatch": 8
+}
+```
+
+In the working bucket, the following would be the structure:
+
+```
+s3://my-working-bucket/
+└── copy-out/
+    └── job-a/
+        ├── INSTRUCTIONS.jsonl
+        ├── ENDED_COPY.csv
+        ├── ENDED_COPY_REPORT.html
+        └── <HeadObjects/Small/Large/NeedThaw*MapRunArn>/{manifest.json, ...}
+```
+
+In the destination bucket, the following would be the structure:
+
+```
+s3://destination/
+└── datasets/
+    └── release/
+        ├── STARTED_COPY.txt
+        ├── ENDED_COPY.csv
+        ├── ENDED_COPY_REPORT.html
+        └── <copied objects>
+```
 
 ### Copying to S3-compatible endpoints
 
@@ -263,7 +382,7 @@ For example, copying to a Ceph bucket using credentials in Secrets Manager:
 
 ```json
 {
-  "copyInstructionsKey": "instructions.jsonl",
+  "copyInstructionsFolder": "job/",
   "destinationBucket": "<bucket-name>",
   "destinationFolderKey": "output/",
   "bucketDefinitions": {

--- a/README.md
+++ b/README.md
@@ -154,57 +154,57 @@ export type StepsS3CopyInvokeArguments = {
   readonly destinationBucket: string;
 
   /**
-   * A slash-terminated prefix in the destination bucket under which copied objects (and the
-   * markers / reports below) are placed. Use `""` to copy into the root of the bucket.
+   * A slash-terminated prefix in the destination bucket which copied objects are placed.
+   * Use `""` to copy into the root of the bucket.
    */
   readonly destinationPrefix?: string;
 
   /**
-   * Slash-terminated prefix (relative to the deploy-time `workingBucketPrefix`) that holds the
-   * input copy-instructions JSONL. Distributed-map result manifests and any retained outputs are
-   * also written here. Use `""` to place at the root of `workingBucketPrefix`.
+   * A slash-terminated prefix, relative to `workingBucketPrefix` that holds the
+   * input copy instructions JSONL. Distributed map result manifests and any retained
+   * outputs are also written here. Use `""` to place at the root of `workingBucketPrefix`.
    */
   readonly instructionsPrefix: string;
 
   /**
-   * Key (relative to `instructionsPrefix`) of the JSONL copy-instructions file. Defaults to
-   * `INSTRUCTIONS.jsonl`. May contain slashes to place the file under a sub-prefix.
+   * The key, relative to `instructionsPrefix` of the JSONL copy instructions file. Defaults to
+   * `INSTRUCTIONS.jsonl`.
    */
   readonly instructionsKey?: string;
 
   /**
-   * Key (relative to `destinationPrefix`) of the start-of-copy marker object. Defaults to
+   * The key, relative to `destinationPrefix` of the start copy marker. Defaults to
    * `STARTED_COPY.txt`.
    */
   readonly startMarkerKey?: string;
 
   /**
-   * Key (relative to `destinationPrefix`) of the end-of-copy CSV summary. Defaults to
+   * The key, relative to `destinationPrefix` of the end copy CSV summary. Defaults to
    * `ENDED_COPY.csv`.
    */
   readonly summaryCsvKey?: string;
 
   /**
-   * Key (relative to `destinationPrefix`) of the end-of-copy HTML report, written when
+   * The key, relative to `destinationPrefix` of the end copy HTML report, written when
    * `htmlReport` is true. Defaults to `ENDED_COPY_REPORT.html`.
    */
   readonly htmlReportKey?: string;
 
   /**
-   * If true, generate and write the HTML report to `destinationPrefix/htmlReportKey` in the
+   * If true, generate and write the HTML report to `<destinationPrefix><htmlReportKey>` in the
    * destination bucket. Defaults to false.
    */
   readonly htmlReport?: boolean;
 
   /**
    * If true, also save the HTML report in the working bucket at
-   * `<workingBucketPrefix><instructionsPrefix><htmlReportKey>`. Generates the report even when
-   * `htmlReport` is false. Defaults to false.
+   * `<workingBucketPrefix><instructionsPrefix><htmlReportKey>`. This will work
+   * for the working bucket even if `htmlReport` is false. Defaults to false.
    */
   readonly retainHtmlReport?: boolean;
 
   /**
-   * If true, also save the end-of-copy CSV in the working bucket at
+   * If true, also save the end copy CSV in the working bucket at
    * `<workingBucketPrefix><instructionsPrefix><summaryCsvKey>`. Defaults to false.
    */
   readonly retainSummaryCsv?: boolean;
@@ -243,11 +243,9 @@ export type StepsS3CopyInvokeArguments = {
   };
 
   /**
-   * When a source or destination bucket matches a key in this map, the `BucketDefinition` is used to
-   * configure the credentials used to access the bucket.
-   *
-   * Settings here will override `sourceRequiredRegion`, `destinationRequiredRegion`, or `sourceNoSignRequest` if
-   * using the no-credential `CredentialProvider`.
+   * When a source or destination bucket matches a key in this map, the `BucketDefinition` is used
+   * to configure the credentials used to access the bucket. Settings here override
+   * `sourceRequiredRegion`, `destinationRequiredRegion`, or `sourceNoSignRequest` for that bucket.
    */
   readonly bucketDefinitions?: Record<string, BucketDefinition>;
 };
@@ -316,7 +314,7 @@ Two buckets are involved in any copy run:
 The `workingBucketPrefix`, `instructionsPrefix`, and `destinationPrefix` inputs must be either an empty string `""`
 or end with a slash.
 
-#### Where each file lands
+#### Where each file end up
 
 The below table summarises each output:
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ export interface StepsS3CopyConstructProps {
    * If undefined or the empty string, then artifacts will be created in the root
    * of the bucket.
    */
-  readonly workingBucketPrefixKey?: string;
+  readonly workingBucketPrefix?: string;
 
   /**
    * Whether the stack should use duration/timeouts that are more suited
@@ -90,7 +90,7 @@ export interface StepsS3CopyConstructProps {
 In order to allow copying objects at the scale we expect (potentially millions of objects) - the input
 list of objects to copy (the "copy instructions")
 is created as a JSONL formatted text file. That file must be
-stored in `workingBucket`/`workingBucketPrefixKey`/... .
+stored in `workingBucket`/`workingBucketPrefix`/... .
 
 Each individual "copy instruction" meets the following schema
 
@@ -137,32 +137,16 @@ orchestration can then be invoked with the following input schema.
 ```typescript
 export type StepsS3CopyInvokeArguments = {
   /**
-   * The region that source buckets MUST be in.
-   *
-   * If undefined, will default to the region that the orchestration is installed into.
+   * The region that source buckets MUST be in. If undefined, defaults to the region the
+   * orchestration is installed in.
    */
   readonly sourceRequiredRegion?: string;
 
   /**
-   * The region that destination bucket MUST be in.
-   *
-   * If undefined, will default to the region that the orchestration is installed into.
+   * The region that the destination bucket MUST be in. If undefined, defaults to the region
+   * the orchestration is installed in.
    */
   readonly destinationRequiredRegion?: string;
-
-  /**
-   * The slash-terminated folder (relative to `workingBucketPrefixKey`) that contains the
-   * copy-instructions JSONL input file. This directory is expected to contain a JSONL file
-   * with the name of `copyInstructionsFileName`. Use `""` to place it at the root of
-   * `workingBucketPrefixKey`.
-   */
-  readonly copyInstructionsFolder: string;
-
-  /**
-   * The name of the JSONL copy-instructions file inside `copyInstructionsFolder`. Defaults
-   * to `INSTRUCTIONS.jsonl` if not specified.
-   */
-  readonly copyInstructionsFileName?: string;
 
   /**
    * The destination bucket to copy the objects.
@@ -170,52 +154,69 @@ export type StepsS3CopyInvokeArguments = {
   readonly destinationBucket: string;
 
   /**
-   * A slash terminated folder key in which to root the destination
-   * objects, or "" to mean place objects in the root of the bucket.
+   * A slash-terminated prefix in the destination bucket under which copied objects (and the
+   * markers / reports below) are placed. Use `""` to copy into the root of the bucket.
    */
-  readonly destinationFolderKey: string;
-
-  readonly copyConcurrency: number;
-  readonly maxItemsPerBatch: number;
+  readonly destinationPrefix?: string;
 
   /**
-   * Relative key (under `destinationFolderKey`) of the start-of-copy marker object.
-   * Defaults to `STARTED_COPY.txt` if omitted.
+   * Slash-terminated prefix (relative to the deploy-time `workingBucketPrefix`) that holds the
+   * input copy-instructions JSONL. Distributed-map result manifests and any retained outputs are
+   * also written here. Use `""` to place at the root of `workingBucketPrefix`.
    */
-  readonly destinationStartCopyRelativeKey?: string;
+  readonly instructionsPrefix: string;
 
   /**
-   * Relative key (under `destinationFolderKey`) of the start copy marker. Defaults to `STARTED_COPY.txt`
-   * if omitted.
+   * Key (relative to `instructionsPrefix`) of the JSONL copy-instructions file. Defaults to
+   * `INSTRUCTIONS.jsonl`. May contain slashes to place the file under a sub-prefix.
    */
-  readonly destinationEndCopyRelativeKey?: string;
+  readonly instructionsKey?: string;
 
   /**
-   * Relative key (under `destinationFolderKey`) of the end copy CSV once the copy completes. Defaults
-   * to `ENDED_COPY.csv` if omitted.
+   * Key (relative to `destinationPrefix`) of the start-of-copy marker object. Defaults to
+   * `STARTED_COPY.txt`.
    */
-  readonly destinationEndCopyReportRelativeKey?: string;
+  readonly startMarkerKey?: string;
 
   /**
-   * If present and true, instructs the copier to go through the motions of
-   * doing a copy (including checking for existence of all the objects) - but not
-   * actually perform the copy.
+   * Key (relative to `destinationPrefix`) of the end-of-copy CSV summary. Defaults to
+   * `ENDED_COPY.csv`.
+   */
+  readonly summaryCsvKey?: string;
+
+  /**
+   * Key (relative to `destinationPrefix`) of the end-of-copy HTML report, written when
+   * `htmlReport` is true. Defaults to `ENDED_COPY_REPORT.html`.
+   */
+  readonly htmlReportKey?: string;
+
+  /**
+   * If true, generate and write the HTML report to `destinationPrefix/htmlReportKey` in the
+   * destination bucket. Defaults to false.
+   */
+  readonly htmlReport?: boolean;
+
+  /**
+   * If true, also save the HTML report in the working bucket at
+   * `<workingBucketPrefix><instructionsPrefix><htmlReportKey>`. Generates the report even when
+   * `htmlReport` is false. Defaults to false.
+   */
+  readonly retainHtmlReport?: boolean;
+
+  /**
+   * If true, also save the end-of-copy CSV in the working bucket at
+   * `<workingBucketPrefix><instructionsPrefix><summaryCsvKey>`. Defaults to false.
+   */
+  readonly retainSummaryCsv?: boolean;
+
+  /**
+   * If true, go through the motions of doing a copy (including checking for existence of all the
+   * objects) - but do not actually perform the copy. Defaults to false.
    */
   readonly dryRun?: boolean;
 
-  /**
-   * If present and true, generate the HTML copy report in the destination
-   * (named by `destinationEndCopyReportRelativeKey`).
-   * If omitted, defaults to false.
-   */
-  readonly includeCopyReport?: boolean;
-
-  /**
-   * If set, also save a copy of the HTML report (named by the basename of
-   * `destinationEndCopyReportRelativeKey`) in the working bucket alongside the copy
-   * instructions file.
-   */
-  readonly retainCopyReport?: boolean;
+  readonly copyConcurrency?: number;
+  readonly maxItemsPerBatch?: number;
 
   /**
    * Optional thawing parameters. Missing `thawParams` is normalised to `{}` by the state machine,
@@ -223,101 +224,113 @@ export type StepsS3CopyInvokeArguments = {
    */
   readonly thawParams?: {
     readonly glacierFlexibleRetrievalThawDays?: number;
-    readonly glacierFlexibleRetrievalThawSpeed?: string;
+    readonly glacierFlexibleRetrievalThawSpeed?:
+      | "Bulk"
+      | "Standard"
+      | "Expedited";
 
     readonly glacierDeepArchiveThawDays?: number;
-    readonly glacierDeepArchiveThawSpeed?: string;
+    readonly glacierDeepArchiveThawSpeed?: "Bulk" | "Standard";
 
     readonly intelligentTieringArchiveThawDays?: number;
-    readonly intelligentTieringArchiveThawSpeed?: string;
+    readonly intelligentTieringArchiveThawSpeed?:
+      | "Bulk"
+      | "Standard"
+      | "Expedited";
 
     readonly intelligentTieringDeepArchiveThawDays?: number;
-    readonly intelligentTieringDeepArchiveThawSpeed?: string;
+    readonly intelligentTieringDeepArchiveThawSpeed?: "Bulk" | "Standard";
   };
 
   /**
-   * When a source or destination bucket matches a key in this map, the BucketDefinition
-   * is used to configure access for the bucket. Access settings here override sourceRequiredRegion,
-   * destinationRequiredRegion, or sourceNoSignRequest for that bucket.
+   * When a source or destination bucket matches a key in this map, the `BucketDefinition` is used to
+   * configure the credentials used to access the bucket.
+   *
+   * Settings here will override `sourceRequiredRegion`, `destinationRequiredRegion`, or `sourceNoSignRequest` if
+   * using the no-credential `CredentialProvider`.
    */
   readonly bucketDefinitions?: Record<string, BucketDefinition>;
 };
 
-type BucketDefinition = {
-  /** The AWS region for this bucket. */
+/**
+ * Common fields shared by all bucket definitions.
+ */
+type BaseBucketDefinition = {
+  /**
+   * The AWS region for this bucket.
+   */
   readonly region?: string;
 
-  /** A custom S3 endpoint URL. */
+  /**
+   * A custom S3 endpoint URL
+   */
   readonly endpointUrl?: string;
 
-  /** Enables S3-compatible mode for endpoints like Ceph. Defaults to true when `endpointUrl` is set,
-   *  although it can be set here to explicitly override.
+  /**
+   * Enables compatibility mode for S3-compatible endpoints.
+   * Defaults to `true` when `endpointUrl` is set. Set explicitly to override this.
    */
   readonly s3Compatible?: boolean;
-
-  /**
-   * Specifies how the copier should connect to a specific bucket.
-   *
-   * - `"default-environment"` - use the default SDK credential chain.
-   * - `"no-credentials"` - no request signing.
-   * - `"aws-secret"` - fetch credentials from an AWS Secrets Manager secret.
-   */
-  readonly credentialProvider?:
-    | "default-environment"
-    | "no-credentials"
-    | "aws-secret";
-
-  /**
-   * The name or ARN of the Secrets Manager secret containing credentials.
-   * This option is required when credentialProvider is "aws-secret". The secret
-   * must be a JSON with `access_key_id`, `secret_access_key`, and optionally `session_token`.
-   */
-  readonly secret?: string;
 };
+
+/**
+ * Specifies how the copier should connect to a specific bucket.
+ *
+ * - `"default-environment"` - use the default SDK credential chain.
+ * - `"no-credentials"` - no request signing.
+ * - `"aws-secret"` - fetch credentials from an AWS Secrets Manager secret.
+ *   The secret must contain JSON with `access_key_id`, `secret_access_key`,
+ *   and optionally `session_token`.
+ */
+export type BucketDefinition = BaseBucketDefinition &
+  (
+    | { readonly credentialProvider?: "default-environment" | "no-credentials" }
+    | { readonly credentialProvider: "aws-secret"; readonly secret: string }
+  );
 ```
 
-`copyInstructionsFolder` points to the slash-terminated folder (relative to the working folder) that
-holds the JSONL copy-instructions file, and `copyInstructionsFileName` names the file itself.
+`instructionsPrefix` points to the slash-terminated prefix (relative to the working folder) that
+holds the JSONL copy-instructions file, and `instructionsKey` names the file itself.
 For instance, if we uploaded the JSONL copy instructions to
 `s3://my-working-bucket/a-working-folder/job/INSTRUCTIONS.jsonl`, we would specify
-`copyInstructionsFolder` of `job/` and leave `copyInstructionsFileName` unset (or set it to
+`instructionsPrefix` of `job/` and leave `instructionsKey` unset (or set it to
 `INSTRUCTIONS.jsonl`).
 
-Outputs of the copy run also land in this same folder, e.g. CSV/HTML reports if
-`retainCopyCsv`/`retainCopyReport` are set, and the distributed-map result manifests.
+Outputs of the copy run also land in this same prefix, e.g. CSV/HTML reports if
+`retainSummaryCsv`/`retainHtmlReport` are set, and the distributed-map result manifests.
 
-Note, it is expected that `copyInstructionsFolder` represents a single copy invocation. A new copy
-should have a different `copyInstructionsFolder`. If it is re-used, the reports and output files will be
+Note, it is expected that `instructionsPrefix` represents a single copy invocation. A new copy
+should have a different `instructionsPrefix`. If it is re-used, the reports and output files will be
 overwritten.
 
 ### File structure in the working and destination buckets
 
 Two buckets are involved in any copy run:
 
-- The **working bucket** (set at deploy time via `workingBucket` + `workingBucketPrefixKey`) holds
+- The **working bucket** (set at deploy time via `workingBucket` + `workingBucketPrefix`) holds
   the JSONL copy-instructions, the per-map result manifests, and any retained copies of the
   CSV summary and HTML report.
-- The **destination bucket** (set per invocation via `destinationBucket` + `destinationFolderKey`)
+- The **destination bucket** (set per invocation via `destinationBucket` + `destinationPrefix`)
   receives the copied objects, the start copy marker, the CSV summary, and optionally the HTML report.
 
-The `workingBucketPrefixKey`, `copyInstructionsFolder`, and `destinationFolderKey` inputs must be either an empty string `""`
+The `workingBucketPrefix`, `instructionsPrefix`, and `destinationPrefix` inputs must be either an empty string `""`
 or end with a slash.
 
 #### Where each file lands
 
 The below table summarises each output:
 
-| Artifact                         | Bucket      | Key                                                                                                                                                            | Controlled by                                                |
-| -------------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| Copy instructions JSONL          | working     | `<workingBucketPrefixKey><copyInstructionsFolder><copyInstructionsFileName>`                                                                                   | uploaded by caller before invocation                         |
-| Distributed map result manifests | working     | `<workingBucketPrefixKey><copyInstructionsFolder><MapRunArn>/manifest.json` and `<workingBucketPrefixKey><copyInstructionsFolder><MapRunArn>/SUCCEEDED_*.json` | HeadObjects, Small, Large, NeedThawSmall, NeedThawLarge maps |
-| Copy set JSONL files             | working     | `<workingBucketPrefixKey><copyInstructionsFolder><HeadObjectsMapRunArn>/{small,large,smallThaw,largeThaw}.jsonl`                                               | CoordinateCopy lambda                                        |
-| Retained CSV summary             | working     | `<workingBucketPrefixKey><copyInstructionsFolder><basename(destinationEndCopyRelativeKey)>`                                                                    | `retainCopyCsv: true`                                        |
-| Retained HTML report             | working     | `<workingBucketPrefixKey><copyInstructionsFolder><basename(destinationEndCopyReportRelativeKey)>`                                                              | `retainCopyReport: true`                                     |
-| Start copy marker                | destination | `<destinationFolderKey><destinationStartCopyRelativeKey>`                                                                                                      | CanWrite lambda                                              |
-| End copy CSV                     | destination | `<destinationFolderKey><destinationEndCopyRelativeKey>`                                                                                                        | SummariseCopy lambda                                         |
-| HTML report                      | destination | `<destinationFolderKey><destinationEndCopyReportRelativeKey>`                                                                                                  | `includeCopyReport: true`                                    |
-| Copied objects                   | destination | `<destinationFolderKey><destinationKey>`                                                                                                                       | per copy-instruction                                         |
+| Artifact                         | Bucket      | Key                                                                                                          | Controlled by                                                |
+| -------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| Copy instructions JSONL          | working     | `<workingBucketPrefix><instructionsPrefix><instructionsKey>`                                                 | uploaded by caller before invocation                         |
+| Distributed map result manifests | working     | `<workingBucketPrefix><instructionsPrefix><MapRunArn>/manifest.json` and `<...><MapRunArn>/SUCCEEDED_*.json` | HeadObjects, Small, Large, NeedThawSmall, NeedThawLarge maps |
+| Copy set JSONL files             | working     | `<workingBucketPrefix><instructionsPrefix><HeadObjectsMapRunArn>/{small,large,smallThaw,largeThaw}.jsonl`    | CoordinateCopy lambda                                        |
+| Retained CSV summary             | working     | `<workingBucketPrefix><instructionsPrefix><summaryCsvKey>`                                                   | `retainSummaryCsv: true`                                     |
+| Retained HTML report             | working     | `<workingBucketPrefix><instructionsPrefix><htmlReportKey>`                                                   | `retainHtmlReport: true`                                     |
+| Start copy marker                | destination | `<destinationPrefix><startMarkerKey>`                                                                        | CanWrite lambda                                              |
+| End copy CSV                     | destination | `<destinationPrefix><summaryCsvKey>`                                                                         | SummariseCopy lambda                                         |
+| HTML report                      | destination | `<destinationPrefix><htmlReportKey>`                                                                         | `htmlReport: true`                                           |
+| Copied objects                   | destination | `<destinationPrefix><destinationKey>`                                                                        | per copy-instruction                                         |
 
 For example, take the following settings to see how files would be laid out.
 
@@ -328,7 +341,7 @@ new StepsS3CopyConstruct(this, "Copy", {
   vpc,
   vpcSubnetSelection: SubnetType.PRIVATE_WITH_EGRESS,
   workingBucket: "my-working-bucket",
-  workingBucketPrefixKey: "copy-out/",
+  workingBucketPrefix: "copy-out/",
 });
 ```
 
@@ -336,12 +349,12 @@ Invoke args:
 
 ```json
 {
-  "copyInstructionsFolder": "job-a/",
+  "instructionsPrefix": "job-a/",
   "destinationBucket": "destination",
-  "destinationFolderKey": "datasets/release/",
-  "includeCopyReport": true,
-  "retainCopyReport": true,
-  "retainCopyCsv": true,
+  "destinationPrefix": "datasets/release/",
+  "htmlReport": true,
+  "retainHtmlReport": true,
+  "retainSummaryCsv": true,
   "copyConcurrency": 80,
   "maxItemsPerBatch": 8
 }
@@ -382,9 +395,9 @@ For example, copying to a Ceph bucket using credentials in Secrets Manager:
 
 ```json
 {
-  "copyInstructionsFolder": "job/",
+  "instructionsPrefix": "job/",
   "destinationBucket": "<bucket-name>",
-  "destinationFolderKey": "output/",
+  "destinationPrefix": "output/",
   "bucketDefinitions": {
     "<bucket-name>": {
       "credentialProvider": "aws-secret",

--- a/dev-testsuite/setup.ts
+++ b/dev-testsuite/setup.ts
@@ -24,11 +24,11 @@ export type TestSetupState = {
 
   // the settings of the state machine under test
   workingBucket: string;
-  workingBucketPrefixKey: string;
+  workingBucketPrefix: string;
 
   // paths for creating various test artefacts
   testInstructionsFolder: string;
-  testInstructionsFileName: string;
+  testInstructionsKey: string;
   testInstructionsAbsolute: string;
   testSrcPrefix: string;
   testDestPrefix: string;
@@ -147,11 +147,11 @@ export async function testSetup(): Promise<TestSetupState> {
     uniqueTestId: unique,
     smArn,
     workingBucket,
-    workingBucketPrefixKey: workingBucketPrefix,
+    workingBucketPrefix,
 
-    // the instructions is inside a folder (relative to workingBucketPrefixKey)
+    // the instructions is inside a folder (relative to workingBucketPrefix)
     testInstructionsFolder: `${unique}/`,
-    testInstructionsFileName: objectsToCopyName,
+    testInstructionsKey: objectsToCopyName,
     testInstructionsAbsolute: `${workingBucketPrefix}${unique}/${objectsToCopyName}`,
 
     testSrcPrefix: `${TEST_BUCKET_ONE_DAY_PREFIX}${unique}SRC/`,

--- a/dev-testsuite/setup.ts
+++ b/dev-testsuite/setup.ts
@@ -27,7 +27,8 @@ export type TestSetupState = {
   workingBucketPrefixKey: string;
 
   // paths for creating various test artefacts
-  testInstructionsRelative: string;
+  testInstructionsFolder: string;
+  testInstructionsFileName: string;
   testInstructionsAbsolute: string;
   testSrcPrefix: string;
   testDestPrefix: string;
@@ -139,13 +140,6 @@ export async function testSetup(): Promise<TestSetupState> {
     "WorkingBucketPrefix",
   );
 
-  // console.log(`Steps Arn = ${smArn}`);
-  // console.log(
-  //  `Working S3 Location = ${workingBucket}/${TEST_BUCKET_WORKING_PREFIX}`,
-  //);
-  // console.log(`Source S3 Bucket = ${sourceBucket}`);
-  // console.log(`Destination S3 Bucket = ${destinationBucket}/<test id>/`);
-
   const objectsToCopyName = `objects-to-copy.jsonl`;
   const unique = randomBytes(8).toString("hex");
 
@@ -155,10 +149,9 @@ export async function testSetup(): Promise<TestSetupState> {
     workingBucket,
     workingBucketPrefixKey: workingBucketPrefix,
 
-    // because our instructions must exist in the working folder - we need it
-    // both as a relative path (how we will refer to it _within_ the steps)
-    // and an absolute path (for use _outside_ our steps)
-    testInstructionsRelative: `${unique}/${objectsToCopyName}`,
+    // the instructions is inside a folder (relative to workingBucketPrefixKey)
+    testInstructionsFolder: `${unique}/`,
+    testInstructionsFileName: objectsToCopyName,
     testInstructionsAbsolute: `${workingBucketPrefix}${unique}/${objectsToCopyName}`,
 
     testSrcPrefix: `${TEST_BUCKET_ONE_DAY_PREFIX}${unique}SRC/`,

--- a/dev-testsuite/test-e2e-ceph.ts
+++ b/dev-testsuite/test-e2e-ceph.ts
@@ -85,10 +85,10 @@ test(
         stateMachineArn: state.smArn,
         name: state.uniqueTestId,
         input: JSON.stringify({
-          copyInstructionsFolder: state.testInstructionsFolder,
-          copyInstructionsFileName: state.testInstructionsFileName,
+          instructionsPrefix: state.testInstructionsFolder,
+          instructionsKey: state.testInstructionsKey,
           destinationBucket: S3_BUCKET,
-          destinationFolderKey: `${state.testDestPrefix}${DEST}`,
+          destinationPrefix: `${state.testDestPrefix}${DEST}`,
           // the destination is not in AWS so disable the region check
           destinationRequiredRegion: "",
           maxItemsPerBatch: 3,

--- a/dev-testsuite/test-e2e-ceph.ts
+++ b/dev-testsuite/test-e2e-ceph.ts
@@ -85,7 +85,8 @@ test(
         stateMachineArn: state.smArn,
         name: state.uniqueTestId,
         input: JSON.stringify({
-          copyInstructionsKey: state.testInstructionsRelative,
+          copyInstructionsFolder: state.testInstructionsFolder,
+          copyInstructionsFileName: state.testInstructionsFileName,
           destinationBucket: S3_BUCKET,
           destinationFolderKey: `${state.testDestPrefix}${DEST}`,
           // the destination is not in AWS so disable the region check

--- a/dev-testsuite/test-e2e-dryrun.ts
+++ b/dev-testsuite/test-e2e-dryrun.ts
@@ -97,10 +97,10 @@ test(
         stateMachineArn: state.smArn,
         name: state.uniqueTestId,
         input: JSON.stringify({
-          copyInstructionsFolder: state.testInstructionsFolder,
-          copyInstructionsFileName: state.testInstructionsFileName,
+          instructionsPrefix: state.testInstructionsFolder,
+          instructionsKey: state.testInstructionsKey,
           destinationBucket: state.workingBucket,
-          destinationFolderKey: `${state.testDestPrefix}${DEST}`,
+          destinationPrefix: `${state.testDestPrefix}${DEST}`,
           maxItemsPerBatch: 3,
           dryRun: true,
         }),

--- a/dev-testsuite/test-e2e-dryrun.ts
+++ b/dev-testsuite/test-e2e-dryrun.ts
@@ -97,7 +97,8 @@ test(
         stateMachineArn: state.smArn,
         name: state.uniqueTestId,
         input: JSON.stringify({
-          copyInstructionsKey: state.testInstructionsRelative,
+          copyInstructionsFolder: state.testInstructionsFolder,
+          copyInstructionsFileName: state.testInstructionsFileName,
           destinationBucket: state.workingBucket,
           destinationFolderKey: `${state.testDestPrefix}${DEST}`,
           maxItemsPerBatch: 3,

--- a/dev-testsuite/test-e2e-koalas.ts
+++ b/dev-testsuite/test-e2e-koalas.ts
@@ -71,7 +71,8 @@ test(
         stateMachineArn: state.smArn,
         name: state.uniqueTestId,
         input: JSON.stringify({
-          copyInstructionsKey: state.testInstructionsRelative,
+          copyInstructionsFolder: state.testInstructionsFolder,
+          copyInstructionsFileName: state.testInstructionsFileName,
           destinationBucket: state.workingBucket,
           destinationFolderKey: state.testDestPrefix,
         }),

--- a/dev-testsuite/test-e2e-koalas.ts
+++ b/dev-testsuite/test-e2e-koalas.ts
@@ -71,10 +71,10 @@ test(
         stateMachineArn: state.smArn,
         name: state.uniqueTestId,
         input: JSON.stringify({
-          copyInstructionsFolder: state.testInstructionsFolder,
-          copyInstructionsFileName: state.testInstructionsFileName,
+          instructionsPrefix: state.testInstructionsFolder,
+          instructionsKey: state.testInstructionsKey,
           destinationBucket: state.workingBucket,
-          destinationFolderKey: state.testDestPrefix,
+          destinationPrefix: state.testDestPrefix,
         }),
       }),
     );

--- a/dev-testsuite/test-e2e-realistic.ts
+++ b/dev-testsuite/test-e2e-realistic.ts
@@ -1,4 +1,9 @@
 import { SFNClient, StartExecutionCommand } from "@aws-sdk/client-sfn";
+import {
+  GetObjectCommand,
+  HeadObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
 import { WaiterState } from "@smithy/util-waiter";
 import { makeObjectDictionaryJsonl } from "./util.mjs";
 import { testSetup, type TestSetupState } from "./setup";
@@ -6,6 +11,7 @@ import { beforeAll, test } from "bun:test";
 import { createTestObject, type TestObject } from "./lib/create-test-object";
 import { waitUntilStateMachineFinishes } from "./lib/steps-waiter.mjs";
 import assert from "node:assert";
+import { dirname } from "node:path/posix";
 import { assertDestinations } from "./lib/assert-destinations.mjs";
 import {
   REALISTIC_SOURCE_OBJECTS,
@@ -78,6 +84,8 @@ test(
           destinationBucket: state.workingBucket,
           destinationFolderKey: `${state.testDestPrefix}${DEST}`,
           maxItemsPerBatch: 3,
+          retainCopyReport: true,
+          retainCopyCsv: true,
         }),
       }),
     );
@@ -98,6 +106,35 @@ test(
       state.workingBucket,
       `${state.testDestPrefix}${DEST}`,
       sourceObjects,
+    );
+
+    const s3Client = new S3Client({});
+    const retainPrefix = dirname(state.testInstructionsRelative) + "/";
+
+    const csvObject = await s3Client.send(
+      new GetObjectCommand({
+        Bucket: state.workingBucket,
+        Key: `${state.testDestPrefix}${DEST}ENDED_COPY.csv`,
+      }),
+    );
+    const csvContent = await csvObject.Body!.transformToString();
+    assert.equal(
+      csvContent.trim().split("\n").length,
+      Object.keys(sourceObjects).length + 1,
+      "CSV row count does not match source objects length + header",
+    );
+
+    await s3Client.send(
+      new HeadObjectCommand({
+        Bucket: state.workingBucket,
+        Key: `${retainPrefix}ENDED_COPY.csv`,
+      }),
+    );
+    await s3Client.send(
+      new HeadObjectCommand({
+        Bucket: state.workingBucket,
+        Key: `${retainPrefix}ENDED_COPY_REPORT.html`,
+      }),
     );
   },
   TEST_EXPECTED_SECONDS * 1000,

--- a/dev-testsuite/test-e2e-realistic.ts
+++ b/dev-testsuite/test-e2e-realistic.ts
@@ -11,12 +11,15 @@ import { beforeAll, test } from "bun:test";
 import { createTestObject, type TestObject } from "./lib/create-test-object";
 import { waitUntilStateMachineFinishes } from "./lib/steps-waiter.mjs";
 import assert from "node:assert";
-import { dirname } from "node:path/posix";
 import { assertDestinations } from "./lib/assert-destinations.mjs";
 import {
   REALISTIC_SOURCE_OBJECTS,
   REALISTIC_WILDCARD_PREFIX,
 } from "./lib/realistic-source-objects";
+import {
+  DEFAULT_DESTINATION_END_COPY_RELATIVE_KEY,
+  DEFAULT_DESTINATION_END_COPY_REPORT_RELATIVE_KEY,
+} from "../packages/steps-s3-copy/src/steps-s3-copy-input";
 
 // we have a few large objects so this can take a few minutes
 const TEST_EXPECTED_SECONDS = 60 * 10;
@@ -80,7 +83,8 @@ test(
         stateMachineArn: state.smArn,
         name: state.uniqueTestId,
         input: JSON.stringify({
-          copyInstructionsKey: state.testInstructionsRelative,
+          copyInstructionsFolder: state.testInstructionsFolder,
+          copyInstructionsFileName: state.testInstructionsFileName,
           destinationBucket: state.workingBucket,
           destinationFolderKey: `${state.testDestPrefix}${DEST}`,
           maxItemsPerBatch: 3,
@@ -109,12 +113,12 @@ test(
     );
 
     const s3Client = new S3Client({});
-    const retainPrefix = dirname(state.testInstructionsRelative) + "/";
+    const retainPrefix = state.testInstructionsFolder;
 
     const csvObject = await s3Client.send(
       new GetObjectCommand({
         Bucket: state.workingBucket,
-        Key: `${state.testDestPrefix}${DEST}ENDED_COPY.csv`,
+        Key: `${state.testDestPrefix}${DEST}${DEFAULT_DESTINATION_END_COPY_RELATIVE_KEY}`,
       }),
     );
     const csvContent = await csvObject.Body!.transformToString();
@@ -127,13 +131,13 @@ test(
     await s3Client.send(
       new HeadObjectCommand({
         Bucket: state.workingBucket,
-        Key: `${retainPrefix}ENDED_COPY.csv`,
+        Key: `${retainPrefix}${DEFAULT_DESTINATION_END_COPY_RELATIVE_KEY}`,
       }),
     );
     await s3Client.send(
       new HeadObjectCommand({
         Bucket: state.workingBucket,
-        Key: `${retainPrefix}ENDED_COPY_REPORT.html`,
+        Key: `${retainPrefix}${DEFAULT_DESTINATION_END_COPY_REPORT_RELATIVE_KEY}`,
       }),
     );
   },

--- a/dev-testsuite/test-e2e-realistic.ts
+++ b/dev-testsuite/test-e2e-realistic.ts
@@ -17,8 +17,8 @@ import {
   REALISTIC_WILDCARD_PREFIX,
 } from "./lib/realistic-source-objects";
 import {
-  DEFAULT_DESTINATION_END_COPY_RELATIVE_KEY,
-  DEFAULT_DESTINATION_END_COPY_REPORT_RELATIVE_KEY,
+  DEFAULT_HTML_REPORT_KEY,
+  DEFAULT_SUMMARY_CSV_KEY,
 } from "../packages/steps-s3-copy/src/steps-s3-copy-input";
 
 // we have a few large objects so this can take a few minutes
@@ -83,13 +83,13 @@ test(
         stateMachineArn: state.smArn,
         name: state.uniqueTestId,
         input: JSON.stringify({
-          copyInstructionsFolder: state.testInstructionsFolder,
-          copyInstructionsFileName: state.testInstructionsFileName,
+          instructionsPrefix: state.testInstructionsFolder,
+          instructionsKey: state.testInstructionsKey,
           destinationBucket: state.workingBucket,
-          destinationFolderKey: `${state.testDestPrefix}${DEST}`,
+          destinationPrefix: `${state.testDestPrefix}${DEST}`,
           maxItemsPerBatch: 3,
-          retainCopyReport: true,
-          retainCopyCsv: true,
+          retainHtmlReport: true,
+          retainSummaryCsv: true,
         }),
       }),
     );
@@ -118,7 +118,7 @@ test(
     const csvObject = await s3Client.send(
       new GetObjectCommand({
         Bucket: state.workingBucket,
-        Key: `${state.testDestPrefix}${DEST}${DEFAULT_DESTINATION_END_COPY_RELATIVE_KEY}`,
+        Key: `${state.testDestPrefix}${DEST}${DEFAULT_SUMMARY_CSV_KEY}`,
       }),
     );
     const csvContent = await csvObject.Body!.transformToString();
@@ -131,13 +131,13 @@ test(
     await s3Client.send(
       new HeadObjectCommand({
         Bucket: state.workingBucket,
-        Key: `${retainPrefix}${DEFAULT_DESTINATION_END_COPY_RELATIVE_KEY}`,
+        Key: `${retainPrefix}${DEFAULT_SUMMARY_CSV_KEY}`,
       }),
     );
     await s3Client.send(
       new HeadObjectCommand({
         Bucket: state.workingBucket,
-        Key: `${retainPrefix}${DEFAULT_DESTINATION_END_COPY_REPORT_RELATIVE_KEY}`,
+        Key: `${retainPrefix}${DEFAULT_HTML_REPORT_KEY}`,
       }),
     );
   },

--- a/dev-testsuite/test-e2e-thawing.ts
+++ b/dev-testsuite/test-e2e-thawing.ts
@@ -100,7 +100,8 @@ test(
         stateMachineArn: state.smArn,
         name: state.uniqueTestId,
         input: JSON.stringify({
-          copyInstructionsKey: state.testInstructionsRelative,
+          copyInstructionsFolder: state.testInstructionsFolder,
+          copyInstructionsFileName: state.testInstructionsFileName,
           destinationBucket: state.workingBucket,
           destinationFolderKey: state.testDestPrefix,
           thawParams: {

--- a/dev-testsuite/test-e2e-thawing.ts
+++ b/dev-testsuite/test-e2e-thawing.ts
@@ -100,10 +100,10 @@ test(
         stateMachineArn: state.smArn,
         name: state.uniqueTestId,
         input: JSON.stringify({
-          copyInstructionsFolder: state.testInstructionsFolder,
-          copyInstructionsFileName: state.testInstructionsFileName,
+          instructionsPrefix: state.testInstructionsFolder,
+          instructionsKey: state.testInstructionsKey,
           destinationBucket: state.workingBucket,
-          destinationFolderKey: state.testDestPrefix,
+          destinationPrefix: state.testDestPrefix,
           thawParams: {
             // Glacier Flexible Retrieval  -->  Expedited
             glacierFlexibleRetrievalThawDays: 1,

--- a/dev-testsuite/test-step-can-write-lambda.ts
+++ b/dev-testsuite/test-step-can-write-lambda.ts
@@ -27,11 +27,12 @@ test.serial("basic", async () => {
       variables: JSON.stringify({
         invokeArguments: {
           destinationBucket: state.workingBucket,
-          destinationPrefixKey: "",
+          destinationPrefix: "",
+          startMarkerKey: "STARTED_COPY.txt",
         },
         invokeSettings: {
           workingBucket: "abcd",
-          workingBucketPrefixKey: "aasd/",
+          workingBucketPrefix: "aasd/",
         },
       }),
     }),
@@ -52,11 +53,12 @@ test.serial("destination bucket in different region", async () => {
           // (there is no way we would ever be able to actually write to this bucket - but the error
           // should occur before we try)
           destinationBucket: "tcga-2-controlled",
-          destinationPrefixKey: "abcd/",
+          destinationPrefix: "abcd/",
+          startMarkerKey: "STARTED_COPY.txt",
         },
         invokeSettings: {
           workingBucket: state.workingBucket,
-          workingBucketPrefixKey: state.workingBucketPrefixKey,
+          workingBucketPrefix: state.workingBucketPrefix,
         },
       }),
     }),

--- a/dev-testsuite/test-step-head-objects-lambda.ts
+++ b/dev-testsuite/test-step-head-objects-lambda.ts
@@ -113,7 +113,7 @@ beforeAll(async () => {
 test.serial("basic functionality", async () => {
   const input: HeadObjectsLambdaInvokeEvent = {
     BatchInput: {
-      destinationFolderKey: DESTINATION_PREFIX,
+      destinationPrefix: DESTINATION_PREFIX,
       maximumExpansion: 5,
     },
     Items: [
@@ -166,7 +166,7 @@ test.serial(
   async () => {
     const input: HeadObjectsLambdaInvokeEvent = {
       BatchInput: {
-        destinationFolderKey: DESTINATION_PREFIX,
+        destinationPrefix: DESTINATION_PREFIX,
         maximumExpansion: 5,
       },
       Items: [
@@ -226,7 +226,7 @@ test.serial(
 
     const input: HeadObjectsLambdaInvokeEvent = {
       BatchInput: {
-        destinationFolderKey: DESTINATION_PREFIX,
+        destinationPrefix: DESTINATION_PREFIX,
         maximumExpansion: 5,
       },
       Items: [
@@ -287,7 +287,7 @@ test.serial(
 test.serial("wildcard expansion with destination prefix", async () => {
   const input: HeadObjectsLambdaInvokeEvent = {
     BatchInput: {
-      destinationFolderKey: DESTINATION_PREFIX,
+      destinationPrefix: DESTINATION_PREFIX,
       maximumExpansion: 5,
     },
     Items: [
@@ -349,7 +349,7 @@ test.serial("wildcard expansion with destination prefix", async () => {
 test.serial("sums data is passed through", async () => {
   const input: HeadObjectsLambdaInvokeEvent = {
     BatchInput: {
-      destinationFolderKey: DESTINATION_PREFIX,
+      destinationPrefix: DESTINATION_PREFIX,
       maximumExpansion: 5,
     },
     Items: [
@@ -385,7 +385,7 @@ test.serial("sums data is passed through", async () => {
 test.serial("missing object will fail", async () => {
   const input: HeadObjectsLambdaInvokeEvent = {
     BatchInput: {
-      destinationFolderKey: DESTINATION_PREFIX,
+      destinationPrefix: DESTINATION_PREFIX,
       maximumExpansion: 5,
     },
     Items: [
@@ -412,7 +412,7 @@ test.serial("missing object will fail", async () => {
 test("wildcard expansion will fail if too many", async () => {
   const input: HeadObjectsLambdaInvokeEvent = {
     BatchInput: {
-      destinationFolderKey: DESTINATION_PREFIX,
+      destinationPrefix: DESTINATION_PREFIX,
       maximumExpansion: 5,
     },
     Items: [
@@ -439,7 +439,7 @@ test("wildcard expansion will fail if too many", async () => {
 test.serial("wildcard expansion will fail if none", async () => {
   const input: HeadObjectsLambdaInvokeEvent = {
     BatchInput: {
-      destinationFolderKey: DESTINATION_PREFIX,
+      destinationPrefix: DESTINATION_PREFIX,
       maximumExpansion: 5,
     },
     Items: [

--- a/dev/dev.ts
+++ b/dev/dev.ts
@@ -99,7 +99,7 @@ class StepsS3CopyStack extends Stack {
       // note for dev we use a public subnet as that is most likely to always be available in a default VPC
       vpcSubnetSelection: SubnetType.PUBLIC,
       workingBucket: workingBucket.bucketName,
-      workingBucketPrefixKey: WORKING_BUCKET_PREFIX,
+      workingBucketPrefix: WORKING_BUCKET_PREFIX,
       aggressiveTimes: true,
       writerRoleName: "steps-s3-copy-role",
       allowWriteToInstalledAccount: true,

--- a/packages/steps-s3-copy/lambda/can-write-lambda/can-write-lambda.ts
+++ b/packages/steps-s3-copy/lambda/can-write-lambda/can-write-lambda.ts
@@ -9,16 +9,31 @@ import type {
   CanWriteLambdaResult,
 } from "../common/can-write-lambda-types";
 import { buildS3Client } from "../common/s3-client-builder";
+import { assertInvokeArgumentString } from "../common/assert-invoke-arguments";
 
 export async function handler(event: CanWriteLambdaInvokeEvent) {
   console.log("canWrite()");
   console.debug(JSON.stringify(event, null, 2));
 
-  if (event.invokeArguments.destinationFolderKey)
-    if (!event.invokeArguments.destinationFolderKey.endsWith("/"))
-      throw new DestinationPrefixKeyNoTrailingSlashError(
-        "The destination prefix sourceKey must either be an empty string or a string with a trailing slash",
-      );
+  // Optional invokeArguments fields are defaulted in the state machine's
+  // "Assign Inputs to State and Apply Defaults" Pass state. These asserts catch the case
+  // where that defaulting was bypassed (e.g. a test invoking this lambda directly).
+  assertInvokeArgumentString(
+    event.invokeArguments.destinationPrefix,
+    "destinationPrefix",
+  );
+  assertInvokeArgumentString(
+    event.invokeArguments.startMarkerKey,
+    "startMarkerKey",
+  );
+
+  if (
+    event.invokeArguments.destinationPrefix &&
+    !event.invokeArguments.destinationPrefix.endsWith("/")
+  )
+    throw new DestinationPrefixKeyNoTrailingSlashError(
+      "The destination prefix must either be an empty string or a string with a trailing slash",
+    );
 
   // we are being super specific here - more so than our normal client creation
   // the "required region" is where we are going
@@ -37,7 +52,7 @@ export async function handler(event: CanWriteLambdaInvokeEvent) {
     } else {
       const putCommand = new PutObjectCommand({
         Bucket: event.invokeArguments.destinationBucket,
-        Key: `${event.invokeArguments.destinationFolderKey}${event.invokeArguments.destinationStartCopyRelativeKey}`,
+        Key: `${event.invokeArguments.destinationPrefix}${event.invokeArguments.startMarkerKey}`,
         Body: "A file created by copy out to ensure correct permissions and to indicate that start of the copy process",
         // we need PutTagging permission to be right - or else rclone will fail when copying our sometimes
         // tagged source files

--- a/packages/steps-s3-copy/lambda/can-write-lambda/can-write-lambda.ts
+++ b/packages/steps-s3-copy/lambda/can-write-lambda/can-write-lambda.ts
@@ -15,9 +15,6 @@ export async function handler(event: CanWriteLambdaInvokeEvent) {
   console.log("canWrite()");
   console.debug(JSON.stringify(event, null, 2));
 
-  // Optional invokeArguments fields are defaulted in the state machine's
-  // "Assign Inputs to State and Apply Defaults" Pass state. These asserts catch the case
-  // where that defaulting was bypassed (e.g. a test invoking this lambda directly).
   assertInvokeArgumentString(
     event.invokeArguments.destinationPrefix,
     "destinationPrefix",

--- a/packages/steps-s3-copy/lambda/can-write-lambda/can-write-lambda.ts
+++ b/packages/steps-s3-copy/lambda/can-write-lambda/can-write-lambda.ts
@@ -2,6 +2,7 @@ import { PutObjectCommand } from "@aws-sdk/client-s3";
 import {
   AccessDeniedError,
   DestinationPrefixKeyNoTrailingSlashError,
+  InstructionsPrefixNoTrailingSlashError,
   WrongRegionError,
 } from "./errors";
 import type {
@@ -23,6 +24,10 @@ export async function handler(event: CanWriteLambdaInvokeEvent) {
     event.invokeArguments.startMarkerKey,
     "startMarkerKey",
   );
+  assertInvokeArgumentString(
+    event.invokeArguments.instructionsPrefix,
+    "instructionsPrefix",
+  );
 
   if (
     event.invokeArguments.destinationPrefix &&
@@ -30,6 +35,14 @@ export async function handler(event: CanWriteLambdaInvokeEvent) {
   )
     throw new DestinationPrefixKeyNoTrailingSlashError(
       "The destination prefix must either be an empty string or a string with a trailing slash",
+    );
+
+  if (
+    event.invokeArguments.instructionsPrefix &&
+    !event.invokeArguments.instructionsPrefix.endsWith("/")
+  )
+    throw new InstructionsPrefixNoTrailingSlashError(
+      "The instructions prefix must either be an empty string or a string with a trailing slash",
     );
 
   // we are being super specific here - more so than our normal client creation

--- a/packages/steps-s3-copy/lambda/can-write-lambda/errors.ts
+++ b/packages/steps-s3-copy/lambda/can-write-lambda/errors.ts
@@ -21,3 +21,11 @@ export class DestinationPrefixKeyNoTrailingSlashError extends Error {
     this.message = message;
   }
 }
+
+export class InstructionsPrefixNoTrailingSlashError extends Error {
+  constructor(message: string) {
+    super();
+    this.name = "InstructionsPrefixNoTrailingSlashError";
+    this.message = message;
+  }
+}

--- a/packages/steps-s3-copy/lambda/common/assert-invoke-arguments.ts
+++ b/packages/steps-s3-copy/lambda/common/assert-invoke-arguments.ts
@@ -1,0 +1,26 @@
+/**
+ * Invariant checks for lambda inputs.
+ */
+
+/**
+ * Asserts that `value` is a string and narrows its type.
+ */
+export function assertInvokeArgumentString(
+  value: unknown,
+  fieldName: string,
+): asserts value is string {
+  if (typeof value !== "string") {
+    throw new InvokeArgumentsInvariantError(
+      `invokeArguments.${fieldName} must be a string after state machine defaulting, ${
+        value === undefined ? "undefined" : typeof value
+      }`,
+    );
+  }
+}
+
+export class InvokeArgumentsInvariantError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvokeArgumentsInvariantError";
+  }
+}

--- a/packages/steps-s3-copy/lambda/coordinate-copy-lambda/coordinate-copy-lambda.ts
+++ b/packages/steps-s3-copy/lambda/coordinate-copy-lambda/coordinate-copy-lambda.ts
@@ -111,6 +111,9 @@ export async function handler(event: LambdaEvent) {
   if (failed.length > 0)
     throw new Error("Copy is meant to succeed - but it had failed results");
 
+  // Each SUCCEEDED result file holds the rows from one batch of the HeadObjects map, iterate all of
+  // them to determine where objects should go.
+  const jsonlParts: string[] = [];
   for (const s of succeeded) {
     console.debug(JSON.stringify(s, null, 2));
 
@@ -121,76 +124,86 @@ export async function handler(event: LambdaEvent) {
       }),
     );
 
-    // note we bring this entirely into memory - whereas we _possibly_ could stream it in to the dataframe -
-    // is fine for the moment - we just allocate a decent amount of memory to this lambda
-    const getSuccessContent = await getSuccessResult.Body!.transformToString();
+    if (!getSuccessResult.Body) {
+      throw new Error("Success S3 object Body is undefined");
+    }
 
-    // Buffer path goes to native `readJson` which supports "lines"
-    const df = pl.readJSON(Buffer.from(getSuccessContent), {
-      // we infer the schema from the entire table
-      inferSchemaLength: null,
-      format: "lines",
-    });
-
-    const stats = await computeStats(df);
-
-    // if we are doing a dry run - then we want to still collect stats etc - but at the end of the day
-    // we will pass an empty list of objects to the actual copiers
-    const emptyDf = df.filter(false);
-
-    // Defining the copy sets based on the size of the objects and their storage class (cold or no)
-
-    // Small objects that do not need thawing
-    const smallDf = df
-      .filter(pl.col("size").ltEq(SIZE_THRESHOLD_BYTES))
-      .filter(pl.col("storageClass").isIn(COLD_STORAGE_CLASSES).not());
-
-    // Small objects that require thawing
-    const smallThawDf = df
-      .filter(pl.col("size").ltEq(SIZE_THRESHOLD_BYTES))
-      .filter(pl.col("storageClass").isIn(COLD_STORAGE_CLASSES));
-
-    // Large objects that do not need thawing
-    const largeDf = df
-      .filter(pl.col("size").gt(SIZE_THRESHOLD_BYTES))
-      .filter(pl.col("storageClass").isIn(COLD_STORAGE_CLASSES).not());
-
-    // Large objects that require thawing
-    const largeThawDf = df
-      .filter(pl.col("size").gt(SIZE_THRESHOLD_BYTES))
-      .filter(pl.col("storageClass").isIn(COLD_STORAGE_CLASSES));
-
-    return {
-      stats: stats,
-      copySets: {
-        small: await createJsonlFromDataFrame(
-          event.headObjectsResults.manifestBucket,
-          event.headObjectsResults.manifestAbsoluteKey,
-          event.invokeArguments.dryRun ? emptyDf : smallDf,
-          "small",
-        ),
-        large: await createJsonlFromDataFrame(
-          event.headObjectsResults.manifestBucket,
-          event.headObjectsResults.manifestAbsoluteKey,
-          event.invokeArguments.dryRun ? emptyDf : largeDf,
-
-          "large",
-        ),
-        smallThaw: await createJsonlFromDataFrame(
-          event.headObjectsResults.manifestBucket,
-          event.headObjectsResults.manifestAbsoluteKey,
-          event.invokeArguments.dryRun ? emptyDf : smallThawDf,
-          "smallThaw",
-        ),
-        largeThaw: await createJsonlFromDataFrame(
-          event.headObjectsResults.manifestBucket,
-          event.headObjectsResults.manifestAbsoluteKey,
-          event.invokeArguments.dryRun ? emptyDf : largeThawDf,
-          "largeThaw",
-        ),
-      },
-    };
+    const content = (await getSuccessResult.Body.transformToString()).trim();
+    if (content.length > 0) jsonlParts.push(content);
   }
+
+  if (jsonlParts.length === 0) {
+    throw new Error(
+      "HeadObjects map produced no result rows, instructions JSONL may be empty",
+    );
+  }
+
+  const combinedJsonl = jsonlParts.join("\n");
+
+  // Buffer path goes to native `readJson` which supports "lines"
+  const df = pl.readJSON(Buffer.from(combinedJsonl), {
+    // we infer the schema from the entire table
+    inferSchemaLength: null,
+    format: "lines",
+  });
+
+  const stats = await computeStats(df);
+
+  // if we are doing a dry run - then we want to still collect stats etc - but at the end of the day
+  // we will pass an empty list of objects to the actual copiers
+  const emptyDf = df.filter(false);
+
+  // Defining the copy sets based on the size of the objects and their storage class (cold or no)
+
+  // Small objects that do not need thawing
+  const smallDf = df
+    .filter(pl.col("size").ltEq(SIZE_THRESHOLD_BYTES))
+    .filter(pl.col("storageClass").isIn(COLD_STORAGE_CLASSES).not());
+
+  // Small objects that require thawing
+  const smallThawDf = df
+    .filter(pl.col("size").ltEq(SIZE_THRESHOLD_BYTES))
+    .filter(pl.col("storageClass").isIn(COLD_STORAGE_CLASSES));
+
+  // Large objects that do not need thawing
+  const largeDf = df
+    .filter(pl.col("size").gt(SIZE_THRESHOLD_BYTES))
+    .filter(pl.col("storageClass").isIn(COLD_STORAGE_CLASSES).not());
+
+  // Large objects that require thawing
+  const largeThawDf = df
+    .filter(pl.col("size").gt(SIZE_THRESHOLD_BYTES))
+    .filter(pl.col("storageClass").isIn(COLD_STORAGE_CLASSES));
+
+  return {
+    stats: stats,
+    copySets: {
+      small: await createJsonlFromDataFrame(
+        event.headObjectsResults.manifestBucket,
+        event.headObjectsResults.manifestAbsoluteKey,
+        event.invokeArguments.dryRun ? emptyDf : smallDf,
+        "small",
+      ),
+      large: await createJsonlFromDataFrame(
+        event.headObjectsResults.manifestBucket,
+        event.headObjectsResults.manifestAbsoluteKey,
+        event.invokeArguments.dryRun ? emptyDf : largeDf,
+        "large",
+      ),
+      smallThaw: await createJsonlFromDataFrame(
+        event.headObjectsResults.manifestBucket,
+        event.headObjectsResults.manifestAbsoluteKey,
+        event.invokeArguments.dryRun ? emptyDf : smallThawDf,
+        "smallThaw",
+      ),
+      largeThaw: await createJsonlFromDataFrame(
+        event.headObjectsResults.manifestBucket,
+        event.headObjectsResults.manifestAbsoluteKey,
+        event.invokeArguments.dryRun ? emptyDf : largeThawDf,
+        "largeThaw",
+      ),
+    },
+  };
 }
 
 /**

--- a/packages/steps-s3-copy/lambda/head-objects-lambda/head-objects-lambda.ts
+++ b/packages/steps-s3-copy/lambda/head-objects-lambda/head-objects-lambda.ts
@@ -16,7 +16,7 @@ import { createS3ClientCache } from "../common/s3-client-builder";
  */
 export type HeadObjectsLambdaInvokeEvent = {
   BatchInput: {
-    destinationFolderKey: string;
+    destinationPrefix: string;
     maximumExpansion: number;
     bucketDefinitions?: Record<string, BucketDefinition>;
   };
@@ -97,23 +97,23 @@ export async function handler(
   // and again and they will be rejected (contrasting this to whether an object does or does not
   // exist for instance - which is a different kind of error)
 
-  // note here that destinationFolderKey CAN BE THE EMPTY STRING - so we do not check for "false" values
-  if (typeof event?.BatchInput?.destinationFolderKey !== "string")
-    throw new DestinationFolderKeyFieldInvalid(
-      "destinationFolderKey must be a slash terminated string or the empty string",
+  // note here that destinationPrefix CAN BE THE EMPTY STRING - so we do not check for "false" values
+  if (typeof event?.BatchInput?.destinationPrefix !== "string")
+    throw new DestinationPrefixFieldInvalid(
+      "destinationPrefix must be a slash terminated string or the empty string",
     );
 
   if (
-    event.BatchInput.destinationFolderKey !== "" &&
-    !event.BatchInput.destinationFolderKey.endsWith("/")
+    event.BatchInput.destinationPrefix !== "" &&
+    !event.BatchInput.destinationPrefix.endsWith("/")
   )
-    throw new DestinationFolderKeyFieldInvalid(
-      "destinationFolderKey must be a slash terminated string or the empty string",
+    throw new DestinationPrefixFieldInvalid(
+      "destinationPrefix must be a slash terminated string or the empty string",
     );
 
-  if (event.BatchInput.destinationFolderKey.includes(".."))
-    throw new DestinationFolderKeyFieldInvalid(
-      "destinationFolderKey cannot contain '..' (which may be interpreted by some systems as a relative path access)",
+  if (event.BatchInput.destinationPrefix.includes(".."))
+    throw new DestinationPrefixFieldInvalid(
+      "destinationPrefix cannot contain '..' (which may be interpreted by some systems as a relative path access)",
     );
 
   for (const o of event.Items || []) {
@@ -247,7 +247,7 @@ export async function handler(
             destinationKey: computeDestinationKey(
               item.Key,
               sourceKeyPrefix + "/",
-              event.BatchInput.destinationFolderKey,
+              event.BatchInput.destinationPrefix,
               o.destinationRelativeFolderKey,
             ),
             etag: item.ETag,
@@ -289,7 +289,7 @@ export async function handler(
         destinationKey: computeDestinationKey(
           o.sourceKey,
           o.sourceRootFolderKey,
-          event.BatchInput.destinationFolderKey,
+          event.BatchInput.destinationPrefix,
           o.destinationRelativeFolderKey,
         ),
         etag: headResult.ETag,
@@ -396,10 +396,10 @@ export class SourceObjectNotFound extends Error {
   }
 }
 
-export class DestinationFolderKeyFieldInvalid extends Error {
+export class DestinationPrefixFieldInvalid extends Error {
   constructor(message: string) {
     super();
-    this.name = "DestinationFolderKeyFieldInvalid";
+    this.name = "DestinationPrefixFieldInvalid";
     this.message = message;
   }
 }

--- a/packages/steps-s3-copy/lambda/summarise-copy-lambda/summarise-copy-lambda.ts
+++ b/packages/steps-s3-copy/lambda/summarise-copy-lambda/summarise-copy-lambda.ts
@@ -1,7 +1,6 @@
 import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
-import { basename } from "path/posix";
+import { basename, dirname, join } from "path/posix";
 import { stringify } from "csv-stringify/sync";
-import { dirname } from "path/posix";
 import { createHtmlReport } from "./create-html-report";
 import type { BucketDefinition } from "../../src/steps-s3-copy-input";
 import { buildS3Client } from "../common/s3-client-builder";
@@ -320,7 +319,7 @@ export async function handler(event: InvokeEvent) {
     // 1) Copy to the destination bucket/folder
     if (includeReport) {
       // TODO: define a better naming scheme for the HTML report (?)
-      htmlKey = csvKey.replace("ENDED_COPY.csv", htmlReportName);
+      htmlKey = join(dirname(csvKey), htmlReportName);
 
       await destClient.send(
         new PutObjectCommand({

--- a/packages/steps-s3-copy/lambda/summarise-copy-lambda/summarise-copy-lambda.ts
+++ b/packages/steps-s3-copy/lambda/summarise-copy-lambda/summarise-copy-lambda.ts
@@ -303,9 +303,9 @@ export async function handler(event: InvokeEvent) {
   const htmlReportName = "ENDED_COPY_REPORT.html";
 
   // Outputs
-  let htmlKey = undefined;
-  let workingCsvKey = undefined;
-  let workingHtmlKey = undefined;
+  let htmlKey: string | undefined = undefined;
+  let workingCsvKey: string | undefined = undefined;
+  let workingHtmlKey: string | undefined = undefined;
 
   if (includeReport || retainReport) {
     // Generate the HTML report

--- a/packages/steps-s3-copy/lambda/summarise-copy-lambda/summarise-copy-lambda.ts
+++ b/packages/steps-s3-copy/lambda/summarise-copy-lambda/summarise-copy-lambda.ts
@@ -27,10 +27,11 @@ interface InvokeEvent {
   destinationPrefixKey: string;
   destinationEndCopyRelativeKey: string;
   workingBucket: string;
-  sourceFilesCsvKey: string;
+  copyInstructionsKey: string;
   bucketDefinitions?: Record<string, BucketDefinition>;
   includeCopyReport?: boolean;
   retainCopyReport?: boolean;
+  retainCopyCsv?: boolean;
 }
 
 type TransferStatus = "ERROR" | "ALREADYCOPIED" | "COPIED";
@@ -299,6 +300,7 @@ export async function handler(event: InvokeEvent) {
   // Determine if we need to generate and store the HTML report(s)
   const includeReport = event.includeCopyReport;
   const retainReport = event.retainCopyReport;
+  const sourceFilePrefix = dirname(event.copyInstructionsKey) + "/";
 
   if (includeReport || retainReport) {
     const htmlReportName = "ENDED_COPY_REPORT.html";
@@ -328,7 +330,6 @@ export async function handler(event: InvokeEvent) {
 
     // 2) Extra copy to a specific S3 URI (sender retention)
     if (retainReport) {
-      const sourceFilePrefix = dirname(event.sourceFilesCsvKey) + "/";
       const retainReportKey = sourceFilePrefix + htmlReportName;
 
       await workingClient.send(
@@ -343,5 +344,16 @@ export async function handler(event: InvokeEvent) {
   }
 
   await destClient.send(putCommand);
-  return output;
+
+  if (event.retainCopyCsv) {
+    await workingClient.send(
+      new PutObjectCommand({
+        Bucket: event.workingBucket,
+        Key: sourceFilePrefix + basename(event.destinationEndCopyRelativeKey),
+        Body: output,
+      }),
+    );
+  }
+
+  return { csvKey };
 }

--- a/packages/steps-s3-copy/lambda/summarise-copy-lambda/summarise-copy-lambda.ts
+++ b/packages/steps-s3-copy/lambda/summarise-copy-lambda/summarise-copy-lambda.ts
@@ -2,37 +2,25 @@ import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import { basename } from "path/posix";
 import { stringify } from "csv-stringify/sync";
 import { createHtmlReport } from "./create-html-report";
-import type { BucketDefinition } from "../../src/steps-s3-copy-input";
+import type { StepsS3CopyInvokeArguments } from "../../src/steps-s3-copy-input";
 import { buildS3Client } from "../common/s3-client-builder";
+import { assertInvokeArgumentString } from "../common/assert-invoke-arguments";
+
+interface MapResult {
+  manifestBucket: string;
+  manifestKey: string;
+}
 
 interface InvokeEvent {
-  rcloneResultsLarge: {
-    manifestBucket: string;
-    manifestKey: string;
+  invokeArguments: StepsS3CopyInvokeArguments;
+  invokeSettings: {
+    workingBucket: string;
+    workingBucketPrefix: string;
   };
-  rcloneResultsSmall: {
-    manifestBucket: string;
-    manifestKey: string;
-  };
-  rcloneResultsNeedThawSmall: {
-    manifestBucket: string;
-    manifestKey: string;
-  };
-  rcloneResultsNeedThawLarge: {
-    manifestBucket: string;
-    manifestKey: string;
-  };
-  destinationBucket: string;
-  destinationPrefixKey: string;
-  destinationEndCopyRelativeKey: string;
-  destinationEndCopyReportRelativeKey: string;
-  workingBucket: string;
-  workingBucketPrefixKey: string;
-  copyInstructionsFolder: string;
-  bucketDefinitions?: Record<string, BucketDefinition>;
-  includeCopyReport?: boolean;
-  retainCopyReport?: boolean;
-  retainCopyCsv?: boolean;
+  rcloneResultsLarge: MapResult;
+  rcloneResultsSmall: MapResult;
+  rcloneResultsNeedThawSmall: MapResult;
+  rcloneResultsNeedThawLarge: MapResult;
 }
 
 type TransferStatus = "ERROR" | "ALREADYCOPIED" | "COPIED";
@@ -60,12 +48,25 @@ export async function handler(event: InvokeEvent) {
   // debug input event
   console.debug(JSON.stringify(event, null, 2));
 
+  assertInvokeArgumentString(
+    event.invokeArguments.destinationPrefix,
+    "destinationPrefix",
+  );
+  assertInvokeArgumentString(
+    event.invokeArguments.summaryCsvKey,
+    "summaryCsvKey",
+  );
+  assertInvokeArgumentString(
+    event.invokeArguments.htmlReportKey,
+    "htmlReportKey",
+  );
+
   // For the working bucket, no bucket definitions are required.
   const workingClient = await buildS3Client();
   // Need to account for bucket definitions for the destination bucket.
   const destClient = await buildS3Client(
-    event.destinationBucket,
-    event.bucketDefinitions,
+    event.invokeArguments.destinationBucket,
+    event.invokeArguments.bucketDefinitions,
   );
 
   // Each Distributed Map we run (Large, Small, NeedThawSmall, NeedThawLarge) writes a
@@ -98,7 +99,7 @@ export async function handler(event: InvokeEvent) {
   // Iterate over the manifest key produced by each map.
   for (const manifestKey of manifestKeys) {
     const getManifestCommand = new GetObjectCommand({
-      Bucket: event.workingBucket,
+      Bucket: event.invokeSettings.workingBucket,
       Key: manifestKey,
     });
 
@@ -155,7 +156,7 @@ export async function handler(event: InvokeEvent) {
   // Process each SUCCEEDED result file to extract stats.
   for (const succeededFile of succeededFiles) {
     const getSuccessCommand = new GetObjectCommand({
-      Bucket: event.workingBucket,
+      Bucket: event.invokeSettings.workingBucket,
       Key: succeededFile["Key"],
     });
 
@@ -287,9 +288,9 @@ export async function handler(event: InvokeEvent) {
   });
 
   // Write the CSV ended copy to the destination S3 bucket/folder
-  const csvKey = `${event.destinationPrefixKey}${event.destinationEndCopyRelativeKey}`;
+  const csvKey = `${event.invokeArguments.destinationPrefix}${event.invokeArguments.summaryCsvKey}`;
   const putCommand = new PutObjectCommand({
-    Bucket: event.destinationBucket,
+    Bucket: event.invokeArguments.destinationBucket,
     Key: csvKey,
     Body: output,
   });
@@ -298,35 +299,38 @@ export async function handler(event: InvokeEvent) {
   // HTML ended copy report generation and storage
   // --------------------------------------------------
 
-  // Determine if we need to generate and store the HTML report(s)
-  const includeReport = event.includeCopyReport;
-  const retainReport = event.retainCopyReport;
-  // This is the in the working bucket where the copy-instructions JSONL lives.
+  // Prefix in the working bucket where the copy-instructions JSONL lives. Used as the destination
+  // for any retained CSV or HTML report.
   const sourceFilePrefix =
-    event.workingBucketPrefixKey + event.copyInstructionsFolder;
+    event.invokeSettings.workingBucketPrefix +
+    event.invokeArguments.instructionsPrefix;
 
   // Outputs
   let htmlKey: string | undefined = undefined;
   let workingCsvKey: string | undefined = undefined;
   let workingHtmlKey: string | undefined = undefined;
 
-  if (includeReport || retainReport) {
+  if (
+    event.invokeArguments.htmlReport ||
+    event.invokeArguments.retainHtmlReport
+  ) {
     // Generate the HTML report
     const html = createHtmlReport({
       title: "Copy Results Report",
       records: Object.values(fileResults) as FileResult[],
-      destinationBucket: event.destinationBucket,
-      destinationFolderKey: event.destinationPrefixKey,
+      destinationBucket: event.invokeArguments.destinationBucket,
+      destinationFolderKey: event.invokeArguments.destinationPrefix,
     });
 
     // 1) Copy to the destination bucket/folder
-    if (includeReport) {
+    if (event.invokeArguments.htmlReport) {
       htmlKey =
-        event.destinationPrefixKey + event.destinationEndCopyReportRelativeKey;
+        event.invokeArguments.destinationPrefix +
+        event.invokeArguments.htmlReportKey;
 
       await destClient.send(
         new PutObjectCommand({
-          Bucket: event.destinationBucket,
+          Bucket: event.invokeArguments.destinationBucket,
           Key: htmlKey,
           Body: html,
           ContentType: "text/html; charset=utf-8",
@@ -335,13 +339,12 @@ export async function handler(event: InvokeEvent) {
     }
 
     // 2) Extra copy to a specific S3 URI (sender retention)
-    if (retainReport) {
-      workingHtmlKey =
-        sourceFilePrefix + basename(event.destinationEndCopyReportRelativeKey);
+    if (event.invokeArguments.retainHtmlReport) {
+      workingHtmlKey = sourceFilePrefix + event.invokeArguments.htmlReportKey;
 
       await workingClient.send(
         new PutObjectCommand({
-          Bucket: event.workingBucket,
+          Bucket: event.invokeSettings.workingBucket,
           Key: workingHtmlKey,
           Body: html,
           ContentType: "text/html; charset=utf-8",
@@ -352,12 +355,11 @@ export async function handler(event: InvokeEvent) {
 
   await destClient.send(putCommand);
 
-  if (event.retainCopyCsv) {
-    workingCsvKey =
-      sourceFilePrefix + basename(event.destinationEndCopyRelativeKey);
+  if (event.invokeArguments.retainSummaryCsv) {
+    workingCsvKey = sourceFilePrefix + event.invokeArguments.summaryCsvKey;
     await workingClient.send(
       new PutObjectCommand({
-        Bucket: event.workingBucket,
+        Bucket: event.invokeSettings.workingBucket,
         Key: workingCsvKey,
         Body: output,
       }),
@@ -365,8 +367,8 @@ export async function handler(event: InvokeEvent) {
   }
 
   return {
-    destinationBucket: event.destinationBucket,
-    workingBucket: event.workingBucket,
+    destinationBucket: event.invokeArguments.destinationBucket,
+    workingBucket: event.invokeSettings.workingBucket,
     csvKey,
     htmlKey,
     workingCsvKey,

--- a/packages/steps-s3-copy/lambda/summarise-copy-lambda/summarise-copy-lambda.ts
+++ b/packages/steps-s3-copy/lambda/summarise-copy-lambda/summarise-copy-lambda.ts
@@ -1,5 +1,5 @@
 import { GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
-import { basename, dirname, join } from "path/posix";
+import { basename } from "path/posix";
 import { stringify } from "csv-stringify/sync";
 import { createHtmlReport } from "./create-html-report";
 import type { BucketDefinition } from "../../src/steps-s3-copy-input";
@@ -25,9 +25,10 @@ interface InvokeEvent {
   destinationBucket: string;
   destinationPrefixKey: string;
   destinationEndCopyRelativeKey: string;
+  destinationEndCopyReportRelativeKey: string;
   workingBucket: string;
   workingBucketPrefixKey: string;
-  copyInstructionsKey: string;
+  copyInstructionsFolder: string;
   bucketDefinitions?: Record<string, BucketDefinition>;
   includeCopyReport?: boolean;
   retainCopyReport?: boolean;
@@ -181,7 +182,7 @@ export async function handler(event: InvokeEvent) {
       // looking
 
       const source = row["source"];
-      // The name is the basename of the source..
+      // The name is the basename of the source.
 
       // Original values
       // const errors: number = rcloneRow["errors"];
@@ -300,9 +301,9 @@ export async function handler(event: InvokeEvent) {
   // Determine if we need to generate and store the HTML report(s)
   const includeReport = event.includeCopyReport;
   const retainReport = event.retainCopyReport;
+  // This is the in the working bucket where the copy-instructions JSONL lives.
   const sourceFilePrefix =
-    event.workingBucketPrefixKey + dirname(event.copyInstructionsKey) + "/";
-  const htmlReportName = "ENDED_COPY_REPORT.html";
+    event.workingBucketPrefixKey + event.copyInstructionsFolder;
 
   // Outputs
   let htmlKey: string | undefined = undefined;
@@ -320,8 +321,8 @@ export async function handler(event: InvokeEvent) {
 
     // 1) Copy to the destination bucket/folder
     if (includeReport) {
-      // TODO: define a better naming scheme for the HTML report (?)
-      htmlKey = join(dirname(csvKey), htmlReportName);
+      htmlKey =
+        event.destinationPrefixKey + event.destinationEndCopyReportRelativeKey;
 
       await destClient.send(
         new PutObjectCommand({
@@ -335,7 +336,8 @@ export async function handler(event: InvokeEvent) {
 
     // 2) Extra copy to a specific S3 URI (sender retention)
     if (retainReport) {
-      workingHtmlKey = sourceFilePrefix + htmlReportName;
+      workingHtmlKey =
+        sourceFilePrefix + basename(event.destinationEndCopyReportRelativeKey);
 
       await workingClient.send(
         new PutObjectCommand({

--- a/packages/steps-s3-copy/lambda/summarise-copy-lambda/summarise-copy-lambda.ts
+++ b/packages/steps-s3-copy/lambda/summarise-copy-lambda/summarise-copy-lambda.ts
@@ -301,10 +301,14 @@ export async function handler(event: InvokeEvent) {
   const includeReport = event.includeCopyReport;
   const retainReport = event.retainCopyReport;
   const sourceFilePrefix = dirname(event.copyInstructionsKey) + "/";
+  const htmlReportName = "ENDED_COPY_REPORT.html";
+
+  // Outputs
+  let htmlKey = undefined;
+  let workingCsvKey = undefined;
+  let workingHtmlKey = undefined;
 
   if (includeReport || retainReport) {
-    const htmlReportName = "ENDED_COPY_REPORT.html";
-
     // Generate the HTML report
     const html = createHtmlReport({
       title: "Copy Results Report",
@@ -316,7 +320,7 @@ export async function handler(event: InvokeEvent) {
     // 1) Copy to the destination bucket/folder
     if (includeReport) {
       // TODO: define a better naming scheme for the HTML report (?)
-      const htmlKey = csvKey.replace("ENDED_COPY.csv", htmlReportName);
+      htmlKey = csvKey.replace("ENDED_COPY.csv", htmlReportName);
 
       await destClient.send(
         new PutObjectCommand({
@@ -330,12 +334,12 @@ export async function handler(event: InvokeEvent) {
 
     // 2) Extra copy to a specific S3 URI (sender retention)
     if (retainReport) {
-      const retainReportKey = sourceFilePrefix + htmlReportName;
+      workingHtmlKey = sourceFilePrefix + htmlReportName;
 
       await workingClient.send(
         new PutObjectCommand({
           Bucket: event.workingBucket,
-          Key: retainReportKey,
+          Key: workingHtmlKey,
           Body: html,
           ContentType: "text/html; charset=utf-8",
         }),
@@ -346,14 +350,23 @@ export async function handler(event: InvokeEvent) {
   await destClient.send(putCommand);
 
   if (event.retainCopyCsv) {
+    workingCsvKey =
+      sourceFilePrefix + basename(event.destinationEndCopyRelativeKey);
     await workingClient.send(
       new PutObjectCommand({
         Bucket: event.workingBucket,
-        Key: sourceFilePrefix + basename(event.destinationEndCopyRelativeKey),
+        Key: workingCsvKey,
         Body: output,
       }),
     );
   }
 
-  return { csvKey };
+  return {
+    destinationBucket: event.destinationBucket,
+    workingBucket: event.workingBucket,
+    csvKey,
+    htmlKey,
+    workingCsvKey,
+    workingHtmlKey,
+  };
 }

--- a/packages/steps-s3-copy/lambda/summarise-copy-lambda/summarise-copy-lambda.ts
+++ b/packages/steps-s3-copy/lambda/summarise-copy-lambda/summarise-copy-lambda.ts
@@ -26,6 +26,7 @@ interface InvokeEvent {
   destinationPrefixKey: string;
   destinationEndCopyRelativeKey: string;
   workingBucket: string;
+  workingBucketPrefixKey: string;
   copyInstructionsKey: string;
   bucketDefinitions?: Record<string, BucketDefinition>;
   includeCopyReport?: boolean;
@@ -299,7 +300,8 @@ export async function handler(event: InvokeEvent) {
   // Determine if we need to generate and store the HTML report(s)
   const includeReport = event.includeCopyReport;
   const retainReport = event.retainCopyReport;
-  const sourceFilePrefix = dirname(event.copyInstructionsKey) + "/";
+  const sourceFilePrefix =
+    event.workingBucketPrefixKey + dirname(event.copyInstructionsKey) + "/";
   const htmlReportName = "ENDED_COPY_REPORT.html";
 
   // Outputs

--- a/packages/steps-s3-copy/src/lib/copy-map-construct.ts
+++ b/packages/steps-s3-copy/src/lib/copy-map-construct.ts
@@ -20,10 +20,6 @@ import {
   ICluster,
   TaskDefinition,
 } from "aws-cdk-lib/aws-ecs";
-import {
-  DESTINATION_BUCKET_FIELD_NAME,
-  MAX_ITEMS_PER_BATCH_FIELD_NAME,
-} from "../steps-s3-copy-input";
 import { Duration } from "aws-cdk-lib";
 import { IRole } from "aws-cdk-lib/aws-iam";
 import { S3JsonlDistributedMap } from "./s3-jsonl-distributed-map";
@@ -156,16 +152,11 @@ export class CopyMapConstruct extends Construct {
         key: JsonPath.stringAt("$.key"),
       }),
       itemBatcher: new ItemBatcher({
-        maxItemsPerBatchPath: `$invokeArguments.${MAX_ITEMS_PER_BATCH_FIELD_NAME}`,
+        maxItemsPerBatchPath: "$invokeArguments.maxItemsPerBatch",
         batchInput: {
           "rcloneDestination.$": JsonPath.format(
             "s3:{}/{}",
-            JsonPath.stringAt(
-              `$invokeArguments.${DESTINATION_BUCKET_FIELD_NAME}`,
-            ),
-            //JsonPath.stringAt(
-            //    `$invokeArguments.${DESTINATION_FOLDER_KEY_FIELD_NAME}`,
-            //),
+            JsonPath.stringAt("$invokeArguments.destinationBucket"),
           ),
         },
       }),
@@ -202,9 +193,7 @@ export class CopyMapConstruct extends Construct {
         ),
         "d.$": JsonPath.format(
           "s3://{}/{}",
-          JsonPath.stringAt(
-            `$invokeArguments.${DESTINATION_BUCKET_FIELD_NAME}`,
-          ),
+          JsonPath.stringAt("$invokeArguments.destinationBucket"),
           JsonPath.stringAt(`$$.Map.Item.Value.destinationKey`),
         ),
       },

--- a/packages/steps-s3-copy/src/lib/copy-map-construct.ts
+++ b/packages/steps-s3-copy/src/lib/copy-map-construct.ts
@@ -24,6 +24,7 @@ import { Duration } from "aws-cdk-lib";
 import { IRole } from "aws-cdk-lib/aws-iam";
 import { S3JsonlDistributedMap } from "./s3-jsonl-distributed-map";
 import { ThawObjectsLambdaStepConstruct } from "./thaw-lambda-step-construct";
+import { invokeArg, invokeSetting } from "../steps-s3-copy-input";
 
 type Props = {
   readonly cluster: ICluster;
@@ -152,11 +153,11 @@ export class CopyMapConstruct extends Construct {
         key: JsonPath.stringAt("$.key"),
       }),
       itemBatcher: new ItemBatcher({
-        maxItemsPerBatchPath: "$invokeArguments.maxItemsPerBatch",
+        maxItemsPerBatchPath: invokeArg("maxItemsPerBatch"),
         batchInput: {
           "rcloneDestination.$": JsonPath.format(
             "s3:{}/{}",
-            JsonPath.stringAt("$invokeArguments.destinationBucket"),
+            JsonPath.stringAt(invokeArg("destinationBucket")),
           ),
         },
       }),
@@ -175,8 +176,8 @@ export class CopyMapConstruct extends Construct {
       maxItemsPerBatch: props.maxItemsPerBatch,
       maxConcurrency: props.maxConcurrency,
       batchInput: {
-        "thawParams.$": "$invokeArguments.thawParams",
-        "bucketDefinitions.$": "$invokeArguments.bucketDefinitions",
+        "thawParams.$": invokeArg("thawParams"),
+        "bucketDefinitions.$": invokeArg("bucketDefinitions"),
       },
       inputPath: props.inputPath,
       itemReader: {
@@ -193,14 +194,14 @@ export class CopyMapConstruct extends Construct {
         ),
         "d.$": JsonPath.format(
           "s3://{}/{}",
-          JsonPath.stringAt("$invokeArguments.destinationBucket"),
+          JsonPath.stringAt(invokeArg("destinationBucket")),
           JsonPath.stringAt(`$$.Map.Item.Value.destinationKey`),
         ),
       },
       iterator: graph,
       // we want to write out the data to S3 as it could be larger than fits in steps payloads
       resultWriter: {
-        "Bucket.$": "$invokeSettings.workingBucket",
+        "Bucket.$": invokeSetting("workingBucket"),
         "Prefix.$": "$mapResultWriterPrefix",
       },
       resultSelector: {

--- a/packages/steps-s3-copy/src/lib/copy-map-construct.ts
+++ b/packages/steps-s3-copy/src/lib/copy-map-construct.ts
@@ -23,7 +23,6 @@ import {
 import {
   DESTINATION_BUCKET_FIELD_NAME,
   MAX_ITEMS_PER_BATCH_FIELD_NAME,
-  COPY_INSTRUCTIONS_KEY_FIELD_NAME,
 } from "../steps-s3-copy-input";
 import { Duration } from "aws-cdk-lib";
 import { IRole } from "aws-cdk-lib/aws-iam";
@@ -172,13 +171,7 @@ export class CopyMapConstruct extends Construct {
       }),
       resultWriterV2: new ResultWriterV2({
         // bucket: JsonPath.stringAt("$invokeSettings.workingBucket"),
-        prefix: JsonPath.format(
-          "{}{}",
-          JsonPath.stringAt("$invokeSettings.workingBucketPrefixKey"),
-          JsonPath.stringAt(
-            `$invokeArguments.${COPY_INSTRUCTIONS_KEY_FIELD_NAME}`,
-          ),
-        ),
+        prefix: JsonPath.stringAt("$mapResultWriterPrefix"),
         writerConfig: new WriterConfig({
           transformation: Transformation.FLATTEN,
           outputType: OutputType.JSONL,
@@ -219,13 +212,7 @@ export class CopyMapConstruct extends Construct {
       // we want to write out the data to S3 as it could be larger than fits in steps payloads
       resultWriter: {
         "Bucket.$": "$invokeSettings.workingBucket",
-        "Prefix.$": JsonPath.format(
-          "{}{}",
-          JsonPath.stringAt("$invokeSettings.workingBucketPrefixKey"),
-          JsonPath.stringAt(
-            `$invokeArguments.${COPY_INSTRUCTIONS_KEY_FIELD_NAME}`,
-          ),
-        ),
+        "Prefix.$": "$mapResultWriterPrefix",
       },
       resultSelector: {
         type: id,

--- a/packages/steps-s3-copy/src/lib/copy-run-task-construct.ts
+++ b/packages/steps-s3-copy/src/lib/copy-run-task-construct.ts
@@ -2,6 +2,7 @@ import { Construct } from "constructs";
 import { IRole } from "aws-cdk-lib/aws-iam";
 import { IntegrationPattern, Timeout } from "aws-cdk-lib/aws-stepfunctions";
 import { Duration } from "aws-cdk-lib";
+import { batchArg } from "../steps-s3-copy-input";
 import {
   ContainerDefinition,
   FargatePlatformVersion,
@@ -102,8 +103,9 @@ export class CopyRunTaskConstruct extends Construct {
             },
             {
               name: "CB_BUCKET_DEFINITIONS",
-              value:
-                "{% $states.input.BatchInput.bucketDefinitions ? $string($states.input.BatchInput.bucketDefinitions) : '{}' %}",
+              value: `{% ${batchArg("bucketDefinitions")} ? $string(${batchArg(
+                "bucketDefinitions",
+              )}) : '{}' %}`,
             },
           ],
         },

--- a/packages/steps-s3-copy/src/lib/head-objects-map-construct.ts
+++ b/packages/steps-s3-copy/src/lib/head-objects-map-construct.ts
@@ -5,7 +5,10 @@ import {
   StateGraph,
 } from "aws-cdk-lib/aws-stepfunctions";
 import { Duration } from "aws-cdk-lib";
-import { COPY_INSTRUCTIONS_KEY_FIELD_NAME } from "../steps-s3-copy-input";
+import {
+  COPY_INSTRUCTIONS_FILE_NAME_FIELD_NAME,
+  COPY_INSTRUCTIONS_FOLDER_FIELD_NAME,
+} from "../steps-s3-copy-input";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { IRole } from "aws-cdk-lib/aws-iam";
 import { S3JsonlDistributedMap } from "./s3-jsonl-distributed-map";
@@ -83,23 +86,20 @@ export class HeadObjectsMapConstruct extends Construct {
       itemReader: {
         "Bucket.$": "$invokeSettings.workingBucket",
         "Key.$": JsonPath.format(
-          "{}{}",
+          "{}{}{}",
           JsonPath.stringAt("$invokeSettings.workingBucketPrefixKey"),
           JsonPath.stringAt(
-            `$invokeArguments.${COPY_INSTRUCTIONS_KEY_FIELD_NAME}`,
+            `$invokeArguments.${COPY_INSTRUCTIONS_FOLDER_FIELD_NAME}`,
+          ),
+          JsonPath.stringAt(
+            `$invokeArguments.${COPY_INSTRUCTIONS_FILE_NAME_FIELD_NAME}`,
           ),
         ),
       },
       iterator: graph,
       resultWriter: {
         "Bucket.$": "$invokeSettings.workingBucket",
-        "Prefix.$": JsonPath.format(
-          "{}{}",
-          JsonPath.stringAt("$invokeSettings.workingBucketPrefixKey"),
-          JsonPath.stringAt(
-            `$invokeArguments.${COPY_INSTRUCTIONS_KEY_FIELD_NAME}`,
-          ),
-        ),
+        "Prefix.$": "$mapResultWriterPrefix",
       },
       assign: {
         headObjectsResults: {

--- a/packages/steps-s3-copy/src/lib/head-objects-map-construct.ts
+++ b/packages/steps-s3-copy/src/lib/head-objects-map-construct.ts
@@ -5,10 +5,6 @@ import {
   StateGraph,
 } from "aws-cdk-lib/aws-stepfunctions";
 import { Duration } from "aws-cdk-lib";
-import {
-  COPY_INSTRUCTIONS_FILE_NAME_FIELD_NAME,
-  COPY_INSTRUCTIONS_FOLDER_FIELD_NAME,
-} from "../steps-s3-copy-input";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { IRole } from "aws-cdk-lib/aws-iam";
 import { S3JsonlDistributedMap } from "./s3-jsonl-distributed-map";
@@ -44,29 +40,6 @@ export class HeadObjectsMapConstruct extends Construct {
       `Map ${id} Iterator`,
     );
 
-    /*new DistributedMap(this, "HOMAP", {
-      toleratedFailurePercentage: 0,
-      itemBatcher: new ItemBatcher({
-        maxInputBytesPerBatch: 16384,
-        batchInput: {
-          "destinationFolderKey.$": JsonPath.stringAt(
-            "$invokeArguments.destinationFolderKey",
-          ),
-          maximumExpansion: 256,
-        },
-      }),
-      itemReader: new S3JsonItemReader({
-        bucketNamePath: "$invokeSettings.workingBucket",
-        key: JsonPath.format(
-          "{}{}",
-          JsonPath.stringAt("$invokeSettings.workingBucketPrefixKey"),
-          JsonPath.stringAt(
-            `$invokeArguments.${COPY_INSTRUCTIONS_KEY_FIELD_NAME}`,
-          ),
-        ),
-      }),
-    }); */
-
     this.distributedMap = new S3JsonlDistributedMap(this, "HeadObjectsMap", {
       // this phase is used to detect errors so we have zero tolerance for files being missing (for instance)
       toleratedFailurePercentage: 0,
@@ -75,8 +48,8 @@ export class HeadObjectsMapConstruct extends Construct {
       // so that means we can fit 256 of them in the standard Steps result payload (256kb)
       maxItemsPerBatch: 1,
       batchInput: {
-        "destinationFolderKey.$": JsonPath.stringAt(
-          "$invokeArguments.destinationFolderKey",
+        "destinationPrefix.$": JsonPath.stringAt(
+          "$invokeArguments.destinationPrefix",
         ),
         maximumExpansion: 256,
         "bucketDefinitions.$": JsonPath.stringAt(
@@ -87,13 +60,9 @@ export class HeadObjectsMapConstruct extends Construct {
         "Bucket.$": "$invokeSettings.workingBucket",
         "Key.$": JsonPath.format(
           "{}{}{}",
-          JsonPath.stringAt("$invokeSettings.workingBucketPrefixKey"),
-          JsonPath.stringAt(
-            `$invokeArguments.${COPY_INSTRUCTIONS_FOLDER_FIELD_NAME}`,
-          ),
-          JsonPath.stringAt(
-            `$invokeArguments.${COPY_INSTRUCTIONS_FILE_NAME_FIELD_NAME}`,
-          ),
+          JsonPath.stringAt("$invokeSettings.workingBucketPrefix"),
+          JsonPath.stringAt("$invokeArguments.instructionsPrefix"),
+          JsonPath.stringAt("$invokeArguments.instructionsKey"),
         ),
       },
       iterator: graph,

--- a/packages/steps-s3-copy/src/lib/head-objects-map-construct.ts
+++ b/packages/steps-s3-copy/src/lib/head-objects-map-construct.ts
@@ -11,6 +11,7 @@ import { S3JsonlDistributedMap } from "./s3-jsonl-distributed-map";
 import { LambdaInvoke } from "aws-cdk-lib/aws-stepfunctions-tasks";
 import { join } from "node:path";
 import { Architecture, Function, Runtime } from "aws-cdk-lib/aws-lambda";
+import { invokeArg, invokeSetting } from "../steps-s3-copy-input";
 
 type Props = {
   readonly writerRole: IRole;
@@ -49,25 +50,25 @@ export class HeadObjectsMapConstruct extends Construct {
       maxItemsPerBatch: 1,
       batchInput: {
         "destinationPrefix.$": JsonPath.stringAt(
-          "$invokeArguments.destinationPrefix",
+          invokeArg("destinationPrefix"),
         ),
         maximumExpansion: 256,
         "bucketDefinitions.$": JsonPath.stringAt(
-          "$invokeArguments.bucketDefinitions",
+          invokeArg("bucketDefinitions"),
         ),
       },
       itemReader: {
-        "Bucket.$": "$invokeSettings.workingBucket",
+        "Bucket.$": invokeSetting("workingBucket"),
         "Key.$": JsonPath.format(
           "{}{}{}",
-          JsonPath.stringAt("$invokeSettings.workingBucketPrefix"),
-          JsonPath.stringAt("$invokeArguments.instructionsPrefix"),
-          JsonPath.stringAt("$invokeArguments.instructionsKey"),
+          JsonPath.stringAt(invokeSetting("workingBucketPrefix")),
+          JsonPath.stringAt(invokeArg("instructionsPrefix")),
+          JsonPath.stringAt(invokeArg("instructionsKey")),
         ),
       },
       iterator: graph,
       resultWriter: {
-        "Bucket.$": "$invokeSettings.workingBucket",
+        "Bucket.$": invokeSetting("workingBucket"),
         "Prefix.$": "$mapResultWriterPrefix",
       },
       assign: {

--- a/packages/steps-s3-copy/src/lib/small-copy-map-construct.ts
+++ b/packages/steps-s3-copy/src/lib/small-copy-map-construct.ts
@@ -1,6 +1,5 @@
 import { Construct } from "constructs";
 import { JsonPath, StateGraph } from "aws-cdk-lib/aws-stepfunctions";
-import { DESTINATION_BUCKET_FIELD_NAME } from "../steps-s3-copy-input";
 import { IRole } from "aws-cdk-lib/aws-iam";
 import { S3JsonlDistributedMap } from "./s3-jsonl-distributed-map";
 import { State } from "aws-cdk-lib/aws-stepfunctions";
@@ -102,9 +101,7 @@ export class SmallObjectsCopyMapConstruct extends Construct {
         ),
         "d.$": JsonPath.format(
           "s3://{}/{}",
-          JsonPath.stringAt(
-            `$invokeArguments.${DESTINATION_BUCKET_FIELD_NAME}`,
-          ),
+          JsonPath.stringAt("$invokeArguments.destinationBucket"),
           JsonPath.stringAt(`$$.Map.Item.Value.destinationKey`),
         ),
       },

--- a/packages/steps-s3-copy/src/lib/small-copy-map-construct.ts
+++ b/packages/steps-s3-copy/src/lib/small-copy-map-construct.ts
@@ -1,9 +1,6 @@
 import { Construct } from "constructs";
 import { JsonPath, StateGraph } from "aws-cdk-lib/aws-stepfunctions";
-import {
-  DESTINATION_BUCKET_FIELD_NAME,
-  COPY_INSTRUCTIONS_KEY_FIELD_NAME,
-} from "../steps-s3-copy-input";
+import { DESTINATION_BUCKET_FIELD_NAME } from "../steps-s3-copy-input";
 import { IRole } from "aws-cdk-lib/aws-iam";
 import { S3JsonlDistributedMap } from "./s3-jsonl-distributed-map";
 import { State } from "aws-cdk-lib/aws-stepfunctions";
@@ -115,13 +112,7 @@ export class SmallObjectsCopyMapConstruct extends Construct {
       // we want to write out the data to S3 as it could be larger than fits in steps payloads
       resultWriter: {
         "Bucket.$": "$invokeSettings.workingBucket",
-        "Prefix.$": JsonPath.format(
-          "{}{}",
-          JsonPath.stringAt("$invokeSettings.workingBucketPrefixKey"),
-          JsonPath.stringAt(
-            `$invokeArguments.${COPY_INSTRUCTIONS_KEY_FIELD_NAME}`,
-          ),
-        ),
+        "Prefix.$": "$mapResultWriterPrefix",
       },
       resultSelector: {
         type: id,

--- a/packages/steps-s3-copy/src/lib/small-copy-map-construct.ts
+++ b/packages/steps-s3-copy/src/lib/small-copy-map-construct.ts
@@ -15,6 +15,7 @@ import {
 import { Platform } from "aws-cdk-lib/aws-ecr-assets";
 import { JitterType } from "aws-cdk-lib/aws-stepfunctions";
 import { join } from "path";
+import { invokeArg, invokeSetting } from "../steps-s3-copy-input";
 
 type Props = {
   readonly writerRole: IRole;
@@ -83,8 +84,8 @@ export class SmallObjectsCopyMapConstruct extends Construct {
       toleratedFailurePercentage: 0,
       maxItemsPerBatch: props.maxItemsPerBatch,
       batchInput: {
-        "thawParams.$": "$invokeArguments.thawParams",
-        "bucketDefinitions.$": "$invokeArguments.bucketDefinitions",
+        "thawParams.$": invokeArg("thawParams"),
+        "bucketDefinitions.$": invokeArg("bucketDefinitions"),
       },
       inputPath: props.inputPath,
       itemReader: {
@@ -101,14 +102,14 @@ export class SmallObjectsCopyMapConstruct extends Construct {
         ),
         "d.$": JsonPath.format(
           "s3://{}/{}",
-          JsonPath.stringAt("$invokeArguments.destinationBucket"),
+          JsonPath.stringAt(invokeArg("destinationBucket")),
           JsonPath.stringAt(`$$.Map.Item.Value.destinationKey`),
         ),
       },
       iterator: graph,
       // we want to write out the data to S3 as it could be larger than fits in steps payloads
       resultWriter: {
-        "Bucket.$": "$invokeSettings.workingBucket",
+        "Bucket.$": invokeSetting("workingBucket"),
         "Prefix.$": "$mapResultWriterPrefix",
       },
       resultSelector: {

--- a/packages/steps-s3-copy/src/lib/summarise-copy-lambda-step-construct.ts
+++ b/packages/steps-s3-copy/src/lib/summarise-copy-lambda-step-construct.ts
@@ -76,6 +76,7 @@ export class SummariseCopyLambdaStepConstruct extends Construct {
         destinationEndCopyRelativeKey:
           "{% $invokeArguments.destinationEndCopyRelativeKey %}",
         workingBucket: "{% $invokeSettings.workingBucket %}",
+        workingBucketPrefixKey: "{% $invokeSettings.workingBucketPrefixKey %}",
         rcloneResultsSmall: "{% $states.input[type='Small'] %}",
         rcloneResultsLarge: "{% $states.input[type='Large'] %}",
         rcloneResultsNeedThawSmall: "{% $states.input[type='NeedThawSmall'] %}",

--- a/packages/steps-s3-copy/src/lib/summarise-copy-lambda-step-construct.ts
+++ b/packages/steps-s3-copy/src/lib/summarise-copy-lambda-step-construct.ts
@@ -71,23 +71,10 @@ export class SummariseCopyLambdaStepConstruct extends Construct {
       payload: TaskInput.fromObject({
         invokeArguments: "{% $invokeArguments %}",
         invokeSettings: "{% $invokeSettings %}",
-        destinationBucket: "{% $invokeArguments.destinationBucket %}",
-        destinationPrefixKey: "{% $invokeArguments.destinationFolderKey %}",
-        destinationEndCopyRelativeKey:
-          "{% $invokeArguments.destinationEndCopyRelativeKey %}",
-        destinationEndCopyReportRelativeKey:
-          "{% $invokeArguments.destinationEndCopyReportRelativeKey %}",
-        workingBucket: "{% $invokeSettings.workingBucket %}",
-        workingBucketPrefixKey: "{% $invokeSettings.workingBucketPrefixKey %}",
         rcloneResultsSmall: "{% $states.input[type='Small'] %}",
         rcloneResultsLarge: "{% $states.input[type='Large'] %}",
         rcloneResultsNeedThawSmall: "{% $states.input[type='NeedThawSmall'] %}",
         rcloneResultsNeedThawLarge: "{% $states.input[type='NeedThawLarge'] %}",
-        bucketDefinitions: "{% $invokeArguments.bucketDefinitions %}",
-        includeCopyReport: "{% $invokeArguments.includeCopyReport %}",
-        retainCopyReport: "{% $invokeArguments.retainCopyReport %}",
-        retainCopyCsv: "{% $invokeArguments.retainCopyCsv %}",
-        copyInstructionsFolder: "{% $invokeArguments.copyInstructionsFolder %}",
       }),
       payloadResponseOnly: true,
     });

--- a/packages/steps-s3-copy/src/lib/summarise-copy-lambda-step-construct.ts
+++ b/packages/steps-s3-copy/src/lib/summarise-copy-lambda-step-construct.ts
@@ -75,6 +75,8 @@ export class SummariseCopyLambdaStepConstruct extends Construct {
         destinationPrefixKey: "{% $invokeArguments.destinationFolderKey %}",
         destinationEndCopyRelativeKey:
           "{% $invokeArguments.destinationEndCopyRelativeKey %}",
+        destinationEndCopyReportRelativeKey:
+          "{% $invokeArguments.destinationEndCopyReportRelativeKey %}",
         workingBucket: "{% $invokeSettings.workingBucket %}",
         workingBucketPrefixKey: "{% $invokeSettings.workingBucketPrefixKey %}",
         rcloneResultsSmall: "{% $states.input[type='Small'] %}",
@@ -85,7 +87,7 @@ export class SummariseCopyLambdaStepConstruct extends Construct {
         includeCopyReport: "{% $invokeArguments.includeCopyReport %}",
         retainCopyReport: "{% $invokeArguments.retainCopyReport %}",
         retainCopyCsv: "{% $invokeArguments.retainCopyCsv %}",
-        copyInstructionsKey: "{% $invokeArguments.copyInstructionsKey %}",
+        copyInstructionsFolder: "{% $invokeArguments.copyInstructionsFolder %}",
       }),
       payloadResponseOnly: true,
     });

--- a/packages/steps-s3-copy/src/lib/summarise-copy-lambda-step-construct.ts
+++ b/packages/steps-s3-copy/src/lib/summarise-copy-lambda-step-construct.ts
@@ -83,6 +83,7 @@ export class SummariseCopyLambdaStepConstruct extends Construct {
         bucketDefinitions: "{% $invokeArguments.bucketDefinitions %}",
         includeCopyReport: "{% $invokeArguments.includeCopyReport %}",
         retainCopyReport: "{% $invokeArguments.retainCopyReport %}",
+        retainCopyCsv: "{% $invokeArguments.retainCopyCsv %}",
         copyInstructionsKey: "{% $invokeArguments.copyInstructionsKey %}",
       }),
       payloadResponseOnly: true,

--- a/packages/steps-s3-copy/src/steps-s3-copy-construct-props.ts
+++ b/packages/steps-s3-copy/src/steps-s3-copy-construct-props.ts
@@ -41,7 +41,7 @@ export interface StepsS3CopyConstructProps {
    * If undefined or the empty string, then artifacts will be created in the root
    * of the bucket.
    */
-  readonly workingBucketPrefixKey?: string;
+  readonly workingBucketPrefix?: string;
 
   /**
    * Whether the stack should use duration/timeouts that are more suited

--- a/packages/steps-s3-copy/src/steps-s3-copy-construct.ts
+++ b/packages/steps-s3-copy/src/steps-s3-copy-construct.ts
@@ -25,6 +25,7 @@ import { ValidateThawParamsLambdaStepConstruct } from "./lib/validate-thaw-param
 import {
   DRY_RUN_KEY_FIELD_NAME,
   INCLUDE_COPY_REPORT_FIELD_NAME,
+  RETAIN_COPY_CSV_FIELD_NAME,
   RETAIN_COPY_REPORT_FIELD_NAME,
   StepsS3CopyInvokeArguments,
 } from "./steps-s3-copy-input";
@@ -186,8 +187,9 @@ export class StepsS3CopyConstruct extends Construct {
       // if not passed, default to false
       [INCLUDE_COPY_REPORT_FIELD_NAME]: `{% [ $states.input.${INCLUDE_COPY_REPORT_FIELD_NAME}, false ][0] %}`,
 
-      // if not passed, default to ""
-      [RETAIN_COPY_REPORT_FIELD_NAME]: `{% [ $states.input.${RETAIN_COPY_REPORT_FIELD_NAME}, "" ][0] %}`,
+      // if not passed, default to false
+      [RETAIN_COPY_REPORT_FIELD_NAME]: `{% [ $states.input.${RETAIN_COPY_REPORT_FIELD_NAME}, false ][0] %}`,
+      [RETAIN_COPY_CSV_FIELD_NAME]: `{% [ $states.input.${RETAIN_COPY_CSV_FIELD_NAME}, false ][0] %}`,
 
       // bucket definitions default to empty object when not provided
       bucketDefinitions: `{% $exists($states.input.bucketDefinitions) ? $states.input.bucketDefinitions : {} %}`,

--- a/packages/steps-s3-copy/src/steps-s3-copy-construct.ts
+++ b/packages/steps-s3-copy/src/steps-s3-copy-construct.ts
@@ -23,6 +23,10 @@ import { Duration, Stack } from "aws-cdk-lib";
 import { CanWriteLambdaStepConstruct } from "./lib/can-write-lambda-step-construct";
 import { ValidateThawParamsLambdaStepConstruct } from "./lib/validate-thaw-params-lambda-step-construct";
 import {
+  DEFAULT_COPY_INSTRUCTIONS_FILE_NAME,
+  DEFAULT_DESTINATION_END_COPY_RELATIVE_KEY,
+  DEFAULT_DESTINATION_END_COPY_REPORT_RELATIVE_KEY,
+  DEFAULT_DESTINATION_START_COPY_RELATIVE_KEY,
   DRY_RUN_KEY_FIELD_NAME,
   INCLUDE_COPY_REPORT_FIELD_NAME,
   RETAIN_COPY_CSV_FIELD_NAME,
@@ -170,14 +174,16 @@ export class StepsS3CopyConstruct extends Construct {
       copyConcurrency:
         "{% [ $number($states.input.copyConcurrency), 80 ][0] %}",
 
-      copyInstructionsKey: `{% $exists($states.input.copyInstructionsKey) ? $states.input.copyInstructionsKey : $error("Missing copyInstructionsKey") %}`,
+      copyInstructionsFolder: `{% $exists($states.input.copyInstructionsFolder) ? $states.input.copyInstructionsFolder : $error("Missing copyInstructionsFolder") %}`,
+      copyInstructionsFileName: `{% [ $states.input.copyInstructionsFileName, "${DEFAULT_COPY_INSTRUCTIONS_FILE_NAME}" ][0] %}`,
       destinationBucket: `{% $exists($states.input.destinationBucket) ? $states.input.destinationBucket : $error("Missing destinationBucket") %}`,
       // set a slash terminated folder to copy into, or by default we just copy into the top level of the destination bucket
       destinationFolderKey: `{% [ $states.input.destinationFolderKey, "" ][0] %}`,
 
       // these are the default objects that will be created in the destination prefix area
-      destinationStartCopyRelativeKey: `{% [ $states.input.destinationStartCopyRelativeKey, "STARTED_COPY.txt" ][0] %}`,
-      destinationEndCopyRelativeKey: `{% [ $states.input.destinationEndCopyRelativeKey, "ENDED_COPY.csv" ][0] %}`,
+      destinationStartCopyRelativeKey: `{% [ $states.input.destinationStartCopyRelativeKey, "${DEFAULT_DESTINATION_START_COPY_RELATIVE_KEY}" ][0] %}`,
+      destinationEndCopyRelativeKey: `{% [ $states.input.destinationEndCopyRelativeKey, "${DEFAULT_DESTINATION_END_COPY_RELATIVE_KEY}" ][0] %}`,
+      destinationEndCopyReportRelativeKey: `{% [ $states.input.destinationEndCopyReportRelativeKey, "${DEFAULT_DESTINATION_END_COPY_REPORT_RELATIVE_KEY}" ][0] %}`,
       // if thawParams is not passed in, we use an empty object
       thawParams: `{% $exists($states.input.thawParams) ? $states.input.thawParams : {} %}`,
 
@@ -202,6 +208,12 @@ export class StepsS3CopyConstruct extends Construct {
       workingBucketPrefixKey: props.workingBucketPrefixKey ?? "",
     };
 
+    // The Distributed Map result writer appends `/<MapRunArn>/...` to its prefix. This produces
+    // a double-slash in the key, so remove it here and pass it into each construct to be referenced.
+    const mapResultWriterPrefix = `{% $replace("${
+      props.workingBucketPrefixKey ?? ""
+    }" & $states.input.copyInstructionsFolder, /\\/$/, "") %}`;
+
     const assignInputsAndApplyDefaults = new Pass(
       this,
       "Assign Inputs to State and Apply Defaults",
@@ -212,6 +224,7 @@ export class StepsS3CopyConstruct extends Construct {
         assign: {
           invokeArguments: jsonataInvokeArgumentsWithDefaults,
           invokeSettings: jsonataInvokeSettings,
+          mapResultWriterPrefix: mapResultWriterPrefix,
         },
       },
     );

--- a/packages/steps-s3-copy/src/steps-s3-copy-construct.ts
+++ b/packages/steps-s3-copy/src/steps-s3-copy-construct.ts
@@ -23,14 +23,10 @@ import { Duration, Stack } from "aws-cdk-lib";
 import { CanWriteLambdaStepConstruct } from "./lib/can-write-lambda-step-construct";
 import { ValidateThawParamsLambdaStepConstruct } from "./lib/validate-thaw-params-lambda-step-construct";
 import {
-  DEFAULT_COPY_INSTRUCTIONS_FILE_NAME,
-  DEFAULT_DESTINATION_END_COPY_RELATIVE_KEY,
-  DEFAULT_DESTINATION_END_COPY_REPORT_RELATIVE_KEY,
-  DEFAULT_DESTINATION_START_COPY_RELATIVE_KEY,
-  DRY_RUN_KEY_FIELD_NAME,
-  INCLUDE_COPY_REPORT_FIELD_NAME,
-  RETAIN_COPY_CSV_FIELD_NAME,
-  RETAIN_COPY_REPORT_FIELD_NAME,
+  DEFAULT_HTML_REPORT_KEY,
+  DEFAULT_INSTRUCTIONS_KEY,
+  DEFAULT_START_MARKER_KEY,
+  DEFAULT_SUMMARY_CSV_KEY,
   StepsS3CopyInvokeArguments,
 } from "./steps-s3-copy-input";
 import { CopyMapConstruct } from "./lib/copy-map-construct";
@@ -57,7 +53,7 @@ export { SubnetType } from "aws-cdk-lib/aws-ec2";
 
 export type StepsS3CopyInvokeSettings = {
   readonly workingBucket: string;
-  readonly workingBucketPrefixKey: string;
+  readonly workingBucketPrefix: string;
 };
 
 /**
@@ -76,15 +72,15 @@ export class StepsS3CopyConstruct extends Construct {
   constructor(scope: Construct, id: string, props: StepsS3CopyConstructProps) {
     super(scope, id);
 
-    // the working bucket prefix key must be undefined or "" which means use the root, or a key with
+    // the working bucket prefix must be undefined or "" which means use the root, or a key with
     // a trailing slash
-    if (props.workingBucketPrefixKey)
+    if (props.workingBucketPrefix)
       if (
-        props.workingBucketPrefixKey !== "" &&
-        !props.workingBucketPrefixKey.endsWith("/")
+        props.workingBucketPrefix !== "" &&
+        !props.workingBucketPrefix.endsWith("/")
       )
         throw new Error(
-          "If specified, the working bucket prefix key must end with a slash or be the empty string",
+          "If specified, the working bucket prefix must end with a slash or be the empty string",
         );
 
     // we define a fargate cluster in which we will be spinning up all of our compute
@@ -153,49 +149,38 @@ export class StepsS3CopyConstruct extends Construct {
         'Invalid thaw parameters (unsupported restore tier). See the "Validate Thaw Params" task failure details for the specific field and value.',
     });
 
+    // The default region is the region the orchestration is installed in.
+    const installedRegion = Stack.of(this).region;
+
     // jsonata representing all input values to the state machine but with defaults for absent fields
     const jsonataInvokeArgumentsWithDefaults: {
       [K in keyof StepsS3CopyInvokeArguments]: string;
     } = {
-      // out of the box - the copy requires both source and destination buckets to be in the
-      // same region as the deployed software. This minimises the chance of large egress
-      // fees
-      // the expected region can be altered in the input to the copy
-      // specifying an empty string for either of these will allow *any* region
-      sourceRequiredRegion: `{% [ $states.input.sourceRequiredRegion, "${
-        Stack.of(this).region
-      }" ][0] %}`,
-      destinationRequiredRegion: `{% [ $states.input.destinationRequiredRegion, "${
-        Stack.of(this).region
-      }" ][0] %}`,
+      sourceRequiredRegion: `{% [ $states.input.sourceRequiredRegion, "${installedRegion}" ][0] %}`,
+      destinationRequiredRegion: `{% [ $states.input.destinationRequiredRegion, "${installedRegion}" ][0] %}`,
 
-      maxItemsPerBatch:
-        "{% [ $number($states.input.maxItemsPerBatch), 8 ][0] %}",
+      destinationBucket: `{% $exists($states.input.destinationBucket) ? $states.input.destinationBucket : $error("Missing destinationBucket") %}`,
+      destinationPrefix: `{% [ $states.input.destinationPrefix, "" ][0] %}`,
+
+      instructionsPrefix: `{% $exists($states.input.instructionsPrefix) ? $states.input.instructionsPrefix : $error("Missing instructionsPrefix") %}`,
+      instructionsKey: `{% [ $states.input.instructionsKey, "${DEFAULT_INSTRUCTIONS_KEY}" ][0] %}`,
+
+      startMarkerKey: `{% [ $states.input.startMarkerKey, "${DEFAULT_START_MARKER_KEY}" ][0] %}`,
+      summaryCsvKey: `{% [ $states.input.summaryCsvKey, "${DEFAULT_SUMMARY_CSV_KEY}" ][0] %}`,
+      htmlReportKey: `{% [ $states.input.htmlReportKey, "${DEFAULT_HTML_REPORT_KEY}" ][0] %}`,
+
+      htmlReport: "{% [ $states.input.htmlReport, false ][0] %}",
+      retainHtmlReport: "{% [ $states.input.retainHtmlReport, false ][0] %}",
+      retainSummaryCsv: "{% [ $states.input.retainSummaryCsv, false ][0] %}",
+
+      dryRun: "{% [ $states.input.dryRun, false ][0] %}",
       copyConcurrency:
         "{% [ $number($states.input.copyConcurrency), 80 ][0] %}",
+      maxItemsPerBatch:
+        "{% [ $number($states.input.maxItemsPerBatch), 8 ][0] %}",
 
-      copyInstructionsFolder: `{% $exists($states.input.copyInstructionsFolder) ? $states.input.copyInstructionsFolder : $error("Missing copyInstructionsFolder") %}`,
-      copyInstructionsFileName: `{% [ $states.input.copyInstructionsFileName, "${DEFAULT_COPY_INSTRUCTIONS_FILE_NAME}" ][0] %}`,
-      destinationBucket: `{% $exists($states.input.destinationBucket) ? $states.input.destinationBucket : $error("Missing destinationBucket") %}`,
-      // set a slash terminated folder to copy into, or by default we just copy into the top level of the destination bucket
-      destinationFolderKey: `{% [ $states.input.destinationFolderKey, "" ][0] %}`,
-
-      // these are the default objects that will be created in the destination prefix area
-      destinationStartCopyRelativeKey: `{% [ $states.input.destinationStartCopyRelativeKey, "${DEFAULT_DESTINATION_START_COPY_RELATIVE_KEY}" ][0] %}`,
-      destinationEndCopyRelativeKey: `{% [ $states.input.destinationEndCopyRelativeKey, "${DEFAULT_DESTINATION_END_COPY_RELATIVE_KEY}" ][0] %}`,
-      destinationEndCopyReportRelativeKey: `{% [ $states.input.destinationEndCopyReportRelativeKey, "${DEFAULT_DESTINATION_END_COPY_REPORT_RELATIVE_KEY}" ][0] %}`,
       // if thawParams is not passed in, we use an empty object
       thawParams: `{% $exists($states.input.thawParams) ? $states.input.thawParams : {} %}`,
-
-      // typecast any input to a boolean, if left blank or not passed in, we will end up with false
-      [DRY_RUN_KEY_FIELD_NAME]: `{% [ $states.input.${DRY_RUN_KEY_FIELD_NAME}, false ][0] %}`,
-
-      // if not passed, default to false
-      [INCLUDE_COPY_REPORT_FIELD_NAME]: `{% [ $states.input.${INCLUDE_COPY_REPORT_FIELD_NAME}, false ][0] %}`,
-
-      // if not passed, default to false
-      [RETAIN_COPY_REPORT_FIELD_NAME]: `{% [ $states.input.${RETAIN_COPY_REPORT_FIELD_NAME}, false ][0] %}`,
-      [RETAIN_COPY_CSV_FIELD_NAME]: `{% [ $states.input.${RETAIN_COPY_CSV_FIELD_NAME}, false ][0] %}`,
 
       // bucket definitions default to empty object when not provided
       bucketDefinitions: `{% $exists($states.input.bucketDefinitions) ? $states.input.bucketDefinitions : {} %}`,
@@ -205,14 +190,14 @@ export class StepsS3CopyConstruct extends Construct {
     } = {
       workingBucket: props.workingBucket,
       // note: if undefined we instead use an empty string to mean "no leading prefix" in the working bucket
-      workingBucketPrefixKey: props.workingBucketPrefixKey ?? "",
+      workingBucketPrefix: props.workingBucketPrefix ?? "",
     };
 
     // The Distributed Map result writer appends `/<MapRunArn>/...` to its prefix. This produces
     // a double-slash in the key, so remove it here and pass it into each construct to be referenced.
     const mapResultWriterPrefix = `{% $replace("${
-      props.workingBucketPrefixKey ?? ""
-    }" & $states.input.copyInstructionsFolder, /\\/$/, "") %}`;
+      props.workingBucketPrefix ?? ""
+    }" & $states.input.instructionsPrefix, /\\/$/, "") %}`;
 
     const assignInputsAndApplyDefaults = new Pass(
       this,

--- a/packages/steps-s3-copy/src/steps-s3-copy-construct.ts
+++ b/packages/steps-s3-copy/src/steps-s3-copy-construct.ts
@@ -28,6 +28,8 @@ import {
   DEFAULT_START_MARKER_KEY,
   DEFAULT_SUMMARY_CSV_KEY,
   StepsS3CopyInvokeArguments,
+  StepsS3CopyInvokeSettings,
+  stateInput,
 } from "./steps-s3-copy-input";
 import { CopyMapConstruct } from "./lib/copy-map-construct";
 import { StepsS3CopyConstructProps } from "./steps-s3-copy-construct-props";
@@ -49,12 +51,8 @@ import { RetentionDays } from "aws-cdk-lib/aws-logs";
 import { SmallObjectsCopyMapConstruct } from "./lib/small-copy-map-construct";
 
 export { StepsS3CopyConstructProps } from "./steps-s3-copy-construct-props";
+export { StepsS3CopyInvokeSettings } from "./steps-s3-copy-input";
 export { SubnetType } from "aws-cdk-lib/aws-ec2";
-
-export type StepsS3CopyInvokeSettings = {
-  readonly workingBucket: string;
-  readonly workingBucketPrefix: string;
-};
 
 /**
  * A construct that makes a state machine for bulk copying large lists of
@@ -156,34 +154,60 @@ export class StepsS3CopyConstruct extends Construct {
     const jsonataInvokeArgumentsWithDefaults: {
       [K in keyof StepsS3CopyInvokeArguments]: string;
     } = {
-      sourceRequiredRegion: `{% [ $states.input.sourceRequiredRegion, "${installedRegion}" ][0] %}`,
-      destinationRequiredRegion: `{% [ $states.input.destinationRequiredRegion, "${installedRegion}" ][0] %}`,
+      sourceRequiredRegion: `{% [ ${stateInput(
+        "sourceRequiredRegion",
+      )}, "${installedRegion}" ][0] %}`,
+      destinationRequiredRegion: `{% [ ${stateInput(
+        "destinationRequiredRegion",
+      )}, "${installedRegion}" ][0] %}`,
 
-      destinationBucket: `{% $exists($states.input.destinationBucket) ? $states.input.destinationBucket : $error("Missing destinationBucket") %}`,
-      destinationPrefix: `{% [ $states.input.destinationPrefix, "" ][0] %}`,
+      destinationBucket: `{% $exists(${stateInput(
+        "destinationBucket",
+      )}) ? ${stateInput(
+        "destinationBucket",
+      )} : $error("Missing destinationBucket") %}`,
+      destinationPrefix: `{% [ ${stateInput("destinationPrefix")}, "" ][0] %}`,
 
-      instructionsPrefix: `{% $exists($states.input.instructionsPrefix) ? $states.input.instructionsPrefix : $error("Missing instructionsPrefix") %}`,
-      instructionsKey: `{% [ $states.input.instructionsKey, "${DEFAULT_INSTRUCTIONS_KEY}" ][0] %}`,
+      instructionsPrefix: `{% $exists(${stateInput(
+        "instructionsPrefix",
+      )}) ? ${stateInput(
+        "instructionsPrefix",
+      )} : $error("Missing instructionsPrefix") %}`,
+      instructionsKey: `{% [ ${stateInput(
+        "instructionsKey",
+      )}, "${DEFAULT_INSTRUCTIONS_KEY}" ][0] %}`,
 
-      startMarkerKey: `{% [ $states.input.startMarkerKey, "${DEFAULT_START_MARKER_KEY}" ][0] %}`,
-      summaryCsvKey: `{% [ $states.input.summaryCsvKey, "${DEFAULT_SUMMARY_CSV_KEY}" ][0] %}`,
-      htmlReportKey: `{% [ $states.input.htmlReportKey, "${DEFAULT_HTML_REPORT_KEY}" ][0] %}`,
+      startMarkerKey: `{% [ ${stateInput(
+        "startMarkerKey",
+      )}, "${DEFAULT_START_MARKER_KEY}" ][0] %}`,
+      summaryCsvKey: `{% [ ${stateInput(
+        "summaryCsvKey",
+      )}, "${DEFAULT_SUMMARY_CSV_KEY}" ][0] %}`,
+      htmlReportKey: `{% [ ${stateInput(
+        "htmlReportKey",
+      )}, "${DEFAULT_HTML_REPORT_KEY}" ][0] %}`,
 
-      htmlReport: "{% [ $states.input.htmlReport, false ][0] %}",
-      retainHtmlReport: "{% [ $states.input.retainHtmlReport, false ][0] %}",
-      retainSummaryCsv: "{% [ $states.input.retainSummaryCsv, false ][0] %}",
+      htmlReport: `{% [ ${stateInput("htmlReport")}, false ][0] %}`,
+      retainHtmlReport: `{% [ ${stateInput("retainHtmlReport")}, false ][0] %}`,
+      retainSummaryCsv: `{% [ ${stateInput("retainSummaryCsv")}, false ][0] %}`,
 
-      dryRun: "{% [ $states.input.dryRun, false ][0] %}",
-      copyConcurrency:
-        "{% [ $number($states.input.copyConcurrency), 80 ][0] %}",
-      maxItemsPerBatch:
-        "{% [ $number($states.input.maxItemsPerBatch), 8 ][0] %}",
+      dryRun: `{% [ ${stateInput("dryRun")}, false ][0] %}`,
+      copyConcurrency: `{% [ $number(${stateInput(
+        "copyConcurrency",
+      )}), 80 ][0] %}`,
+      maxItemsPerBatch: `{% [ $number(${stateInput(
+        "maxItemsPerBatch",
+      )}), 8 ][0] %}`,
 
       // if thawParams is not passed in, we use an empty object
-      thawParams: `{% $exists($states.input.thawParams) ? $states.input.thawParams : {} %}`,
+      thawParams: `{% $exists(${stateInput("thawParams")}) ? ${stateInput(
+        "thawParams",
+      )} : {} %}`,
 
       // bucket definitions default to empty object when not provided
-      bucketDefinitions: `{% $exists($states.input.bucketDefinitions) ? $states.input.bucketDefinitions : {} %}`,
+      bucketDefinitions: `{% $exists(${stateInput(
+        "bucketDefinitions",
+      )}) ? ${stateInput("bucketDefinitions")} : {} %}`,
     };
     const jsonataInvokeSettings: {
       [K in keyof StepsS3CopyInvokeSettings]: string;
@@ -197,7 +221,7 @@ export class StepsS3CopyConstruct extends Construct {
     // a double-slash in the key, so remove it here and pass it into each construct to be referenced.
     const mapResultWriterPrefix = `{% $replace("${
       props.workingBucketPrefix ?? ""
-    }" & $states.input.instructionsPrefix, /\\/$/, "") %}`;
+    }" & ${stateInput("instructionsPrefix")}, /\\/$/, "") %}`;
 
     const assignInputsAndApplyDefaults = new Pass(
       this,

--- a/packages/steps-s3-copy/src/steps-s3-copy-input.ts
+++ b/packages/steps-s3-copy/src/steps-s3-copy-input.ts
@@ -20,10 +20,18 @@ export type StepsS3CopyInvokeArguments = {
   readonly destinationRequiredRegion?: string;
 
   /**
-   * The relative path (relative to `workingBucketPrefixKey`) to the copy-instructions input file.
-   * This file is JSONL: one `CopyInstruction` per line.
+   * The slash-terminated folder (relative to `workingBucketPrefixKey`) that contains the
+   * copy-instructions JSONL input file. This directory is expected to contain a JSONL file
+   * with the name of `copyInstructionsFileName`. Use `""` to place it at the root of
+   * `workingBucketPrefixKey`.
    */
-  readonly copyInstructionsKey: string;
+  readonly copyInstructionsFolder: string;
+
+  /**
+   * The name of the JSONL copy-instructions file inside `copyInstructionsFolder`. Defaults
+   * to `INSTRUCTIONS.jsonl` if not specified.
+   */
+  readonly copyInstructionsFileName?: string;
 
   /**
    * The destination bucket to copy the objects.
@@ -39,8 +47,23 @@ export type StepsS3CopyInvokeArguments = {
   readonly copyConcurrency: number;
   readonly maxItemsPerBatch: number;
 
-  readonly destinationStartCopyRelativeKey: string;
-  readonly destinationEndCopyRelativeKey: string;
+  /**
+   * Relative key (under `destinationFolderKey`) of the start copy marker. Defaults to `STARTED_COPY.txt`
+   * if omitted.
+   */
+  readonly destinationStartCopyRelativeKey?: string;
+
+  /**
+   * Relative key (under `destinationFolderKey`) of the end copy CSV once the copy completes. Defaults
+   * to `ENDED_COPY.csv` if omitted.
+   */
+  readonly destinationEndCopyRelativeKey?: string;
+
+  /**
+   * Relative key (under `destinationFolderKey`) of the end copy HTML report written  when `includeCopyReport`
+   * is also set. Defaults to `ENDED_COPY_REPORT.html` if not specified.
+   */
+  readonly destinationEndCopyReportRelativeKey?: string;
 
   /**
    * If present and true, instructs the copier to go through the motions of
@@ -104,8 +127,13 @@ export type CopyOutStateMachineInputKeys = keyof StepsS3CopyInvokeArguments;
 // this odd construct just makes sure that the JSON paths we specify
 // here correspond with fields in the master "input" schema for the
 // overall Steps function
-export const COPY_INSTRUCTIONS_KEY_FIELD_NAME: CopyOutStateMachineInputKeys =
-  "copyInstructionsKey";
+export const COPY_INSTRUCTIONS_FOLDER_FIELD_NAME: CopyOutStateMachineInputKeys =
+  "copyInstructionsFolder";
+
+export const COPY_INSTRUCTIONS_FILE_NAME_FIELD_NAME: CopyOutStateMachineInputKeys =
+  "copyInstructionsFileName";
+
+export const DEFAULT_COPY_INSTRUCTIONS_FILE_NAME = "INSTRUCTIONS.jsonl";
 
 export const MAX_ITEMS_PER_BATCH_FIELD_NAME: CopyOutStateMachineInputKeys =
   "maxItemsPerBatch";
@@ -119,6 +147,13 @@ export const DESTINATION_START_COPY_RELATIVE_KEY_FIELD_NAME: CopyOutStateMachine
   "destinationStartCopyRelativeKey";
 export const DESTINATION_END_COPY_RELATIVE_KEY_FIELD_NAME: CopyOutStateMachineInputKeys =
   "destinationEndCopyRelativeKey";
+export const DESTINATION_END_COPY_REPORT_RELATIVE_KEY_FIELD_NAME: CopyOutStateMachineInputKeys =
+  "destinationEndCopyReportRelativeKey";
+
+export const DEFAULT_DESTINATION_START_COPY_RELATIVE_KEY = "STARTED_COPY.txt";
+export const DEFAULT_DESTINATION_END_COPY_RELATIVE_KEY = "ENDED_COPY.csv";
+export const DEFAULT_DESTINATION_END_COPY_REPORT_RELATIVE_KEY =
+  "ENDED_COPY_REPORT.html";
 
 export const DRY_RUN_KEY_FIELD_NAME: CopyOutStateMachineInputKeys = "dryRun";
 

--- a/packages/steps-s3-copy/src/steps-s3-copy-input.ts
+++ b/packages/steps-s3-copy/src/steps-s3-copy-input.ts
@@ -118,6 +118,39 @@ export type StepsS3CopyInvokeArguments = {
   readonly bucketDefinitions?: Record<string, BucketDefinition>;
 };
 
+/**
+ * Settings the construct bakes into the state machine at deploy time, as opposed to
+ * `StepsS3CopyInvokeArguments` which are supplied per execution.
+ */
+export type StepsS3CopyInvokeSettings = {
+  readonly workingBucket: string;
+  readonly workingBucketPrefix: string;
+};
+
+/**
+ * Builds a JSONPath reference into the `$invokeArguments` state variable.
+ */
+export const invokeArg = (key: keyof StepsS3CopyInvokeArguments): string =>
+  `$invokeArguments.${key}`;
+
+/**
+ * Builds a JSONPath reference into the `$invokeSettings` state variable.
+ */
+export const invokeSetting = (key: keyof StepsS3CopyInvokeSettings): string =>
+  `$invokeSettings.${key}`;
+
+/**
+ * Builds a JSONata reference to a field of the raw caller `$states.input` variable.
+ */
+export const stateInput = (key: keyof StepsS3CopyInvokeArguments): string =>
+  `$states.input.${key}`;
+
+/**
+ * Builds a JSONata reference to a field of the batch `$states.input.BatchInput.<key>` object.
+ */
+export const batchArg = (key: keyof StepsS3CopyInvokeArguments): string =>
+  `$states.input.BatchInput.${key}`;
+
 // Default file names used when the corresponding input override is not supplied.
 export const DEFAULT_INSTRUCTIONS_KEY = "INSTRUCTIONS.jsonl";
 export const DEFAULT_START_MARKER_KEY = "STARTED_COPY.txt";

--- a/packages/steps-s3-copy/src/steps-s3-copy-input.ts
+++ b/packages/steps-s3-copy/src/steps-s3-copy-input.ts
@@ -61,6 +61,11 @@ export type StepsS3CopyInvokeArguments = {
   readonly retainCopyReport?: boolean;
 
   /**
+   * If set, also save the ended copy CSV to the working bucket alongside the copy instructions file.
+   */
+  readonly retainCopyCsv?: boolean;
+
+  /**
    * Optional thawing parameters. Missing `thawParams` is normalised to `{}` by the state machine,
    * and per-field defaults are applied by the thaw step Lambda (`*ThawDays` = 1, `*ThawSpeed` = "Bulk").
    */
@@ -122,6 +127,9 @@ export const INCLUDE_COPY_REPORT_FIELD_NAME: CopyOutStateMachineInputKeys =
 
 export const RETAIN_COPY_REPORT_FIELD_NAME: CopyOutStateMachineInputKeys =
   "retainCopyReport";
+
+export const RETAIN_COPY_CSV_FIELD_NAME: CopyOutStateMachineInputKeys =
+  "retainCopyCsv";
 
 /**
  * Common fields shared by all bucket definitions.

--- a/packages/steps-s3-copy/src/steps-s3-copy-input.ts
+++ b/packages/steps-s3-copy/src/steps-s3-copy-input.ts
@@ -3,35 +3,18 @@
  * This is more for internal consistency - it is not directly
  * used to define the "schema" of the state machine.
  */
-
 export type StepsS3CopyInvokeArguments = {
   /**
-   * The region that source buckets MUST be in.
-   *
-   * If undefined, will default to the region that the orchestration is installed in.
+   * The region that source buckets MUST be in. If undefined, defaults to the region the
+   * orchestration is installed in.
    */
   readonly sourceRequiredRegion?: string;
 
   /**
-   * The region that destination bucket MUST be in.
-   *
-   * If undefined, will default to the region that the orchestration is installed in.
+   * The region that the destination bucket MUST be in. If undefined, defaults to the region
+   * the orchestration is installed in.
    */
   readonly destinationRequiredRegion?: string;
-
-  /**
-   * The slash-terminated folder (relative to `workingBucketPrefixKey`) that contains the
-   * copy-instructions JSONL input file. This directory is expected to contain a JSONL file
-   * with the name of `copyInstructionsFileName`. Use `""` to place it at the root of
-   * `workingBucketPrefixKey`.
-   */
-  readonly copyInstructionsFolder: string;
-
-  /**
-   * The name of the JSONL copy-instructions file inside `copyInstructionsFolder`. Defaults
-   * to `INSTRUCTIONS.jsonl` if not specified.
-   */
-  readonly copyInstructionsFileName?: string;
 
   /**
    * The destination bucket to copy the objects.
@@ -39,54 +22,69 @@ export type StepsS3CopyInvokeArguments = {
   readonly destinationBucket: string;
 
   /**
-   * A slash terminated folder key in which to root the destination
-   * objects, or "" to mean place objects in the root of the bucket.
+   * A slash-terminated prefix in the destination bucket which copied objects are placed.
+   * Use `""` to copy into the root of the bucket.
    */
-  readonly destinationFolderKey: string;
-
-  readonly copyConcurrency: number;
-  readonly maxItemsPerBatch: number;
+  readonly destinationPrefix?: string;
 
   /**
-   * Relative key (under `destinationFolderKey`) of the start copy marker. Defaults to `STARTED_COPY.txt`
-   * if omitted.
+   * A slash-terminated prefix, relative to `workingBucketPrefix` that holds the
+   * input copy instructions JSONL. Distributed map result manifests and any retained
+   * outputs are also written here. Use `""` to place at the root of `workingBucketPrefix`.
    */
-  readonly destinationStartCopyRelativeKey?: string;
+  readonly instructionsPrefix: string;
 
   /**
-   * Relative key (under `destinationFolderKey`) of the end copy CSV once the copy completes. Defaults
-   * to `ENDED_COPY.csv` if omitted.
+   * The key, relative to `instructionsPrefix` of the JSONL copy instructions file. Defaults to
+   * `INSTRUCTIONS.jsonl`.
    */
-  readonly destinationEndCopyRelativeKey?: string;
+  readonly instructionsKey?: string;
 
   /**
-   * Relative key (under `destinationFolderKey`) of the end copy HTML report written  when `includeCopyReport`
-   * is also set. Defaults to `ENDED_COPY_REPORT.html` if not specified.
+   * The key, relative to `destinationPrefix` of the start copy marker. Defaults to
+   * `STARTED_COPY.txt`.
    */
-  readonly destinationEndCopyReportRelativeKey?: string;
+  readonly startMarkerKey?: string;
 
   /**
-   * If present and true, instructs the copier to go through the motions of
-   * doing a copy (including checking for existence of all the objects) - but not
-   * actually perform the copy.
+   * The key, relative to `destinationPrefix` of the end copy CSV summary. Defaults to
+   * `ENDED_COPY.csv`.
+   */
+  readonly summaryCsvKey?: string;
+
+  /**
+   * The key, relative to `destinationPrefix` of the end copy HTML report, written when
+   * `htmlReport` is true. Defaults to `ENDED_COPY_REPORT.html`.
+   */
+  readonly htmlReportKey?: string;
+
+  /**
+   * If true, generate and write the HTML report to `<destinationPrefix><htmlReportKey>` in the
+   * destination bucket. Defaults to false.
+   */
+  readonly htmlReport?: boolean;
+
+  /**
+   * If true, also save the HTML report in the working bucket at
+   * `<workingBucketPrefix><instructionsPrefix><htmlReportKey>`. This will work
+   * for the working bucket even if `htmlReport` is false. Defaults to false.
+   */
+  readonly retainHtmlReport?: boolean;
+
+  /**
+   * If true, also save the end copy CSV in the working bucket at
+   * `<workingBucketPrefix><instructionsPrefix><summaryCsvKey>`. Defaults to false.
+   */
+  readonly retainSummaryCsv?: boolean;
+
+  /**
+   * If true, go through the motions of doing a copy (including checking for existence of all the
+   * objects) - but do not actually perform the copy. Defaults to false.
    */
   readonly dryRun?: boolean;
 
-  /**
-   * If present and true, generate html copy report (COPY_REPORT.html)  in the destination.
-   * If omitted, defaults to false.
-   */
-  readonly includeCopyReport?: boolean;
-
-  /**
-   * If set, also save a copy report (COPY_REPORT.html) in the same bucket and prefix as the source file.
-   */
-  readonly retainCopyReport?: boolean;
-
-  /**
-   * If set, also save the ended copy CSV to the working bucket alongside the copy instructions file.
-   */
-  readonly retainCopyCsv?: boolean;
+  readonly copyConcurrency?: number;
+  readonly maxItemsPerBatch?: number;
 
   /**
    * Optional thawing parameters. Missing `thawParams` is normalised to `{}` by the state machine,
@@ -113,58 +111,18 @@ export type StepsS3CopyInvokeArguments = {
   };
 
   /**
-   * When a source or destination bucket matches a key in this map, the `BucketDefinition` is used to
-   * configure the credentials used to access the bucket.
-   *
-   * Settings here will override `sourceRequiredRegion`, `destinationRequiredRegion`, or `sourceNoSignRequest` if
-   * using the no-credential `CredentialProvider`.
+   * When a source or destination bucket matches a key in this map, the `BucketDefinition` is used
+   * to configure the credentials used to access the bucket. Settings here override
+   * `sourceRequiredRegion`, `destinationRequiredRegion`, or `sourceNoSignRequest` for that bucket.
    */
   readonly bucketDefinitions?: Record<string, BucketDefinition>;
 };
 
-export type CopyOutStateMachineInputKeys = keyof StepsS3CopyInvokeArguments;
-
-// this odd construct just makes sure that the JSON paths we specify
-// here correspond with fields in the master "input" schema for the
-// overall Steps function
-export const COPY_INSTRUCTIONS_FOLDER_FIELD_NAME: CopyOutStateMachineInputKeys =
-  "copyInstructionsFolder";
-
-export const COPY_INSTRUCTIONS_FILE_NAME_FIELD_NAME: CopyOutStateMachineInputKeys =
-  "copyInstructionsFileName";
-
-export const DEFAULT_COPY_INSTRUCTIONS_FILE_NAME = "INSTRUCTIONS.jsonl";
-
-export const MAX_ITEMS_PER_BATCH_FIELD_NAME: CopyOutStateMachineInputKeys =
-  "maxItemsPerBatch";
-
-export const DESTINATION_BUCKET_FIELD_NAME: CopyOutStateMachineInputKeys =
-  "destinationBucket";
-export const DESTINATION_FOLDER_KEY_FIELD_NAME: CopyOutStateMachineInputKeys =
-  "destinationFolderKey";
-
-export const DESTINATION_START_COPY_RELATIVE_KEY_FIELD_NAME: CopyOutStateMachineInputKeys =
-  "destinationStartCopyRelativeKey";
-export const DESTINATION_END_COPY_RELATIVE_KEY_FIELD_NAME: CopyOutStateMachineInputKeys =
-  "destinationEndCopyRelativeKey";
-export const DESTINATION_END_COPY_REPORT_RELATIVE_KEY_FIELD_NAME: CopyOutStateMachineInputKeys =
-  "destinationEndCopyReportRelativeKey";
-
-export const DEFAULT_DESTINATION_START_COPY_RELATIVE_KEY = "STARTED_COPY.txt";
-export const DEFAULT_DESTINATION_END_COPY_RELATIVE_KEY = "ENDED_COPY.csv";
-export const DEFAULT_DESTINATION_END_COPY_REPORT_RELATIVE_KEY =
-  "ENDED_COPY_REPORT.html";
-
-export const DRY_RUN_KEY_FIELD_NAME: CopyOutStateMachineInputKeys = "dryRun";
-
-export const INCLUDE_COPY_REPORT_FIELD_NAME: CopyOutStateMachineInputKeys =
-  "includeCopyReport";
-
-export const RETAIN_COPY_REPORT_FIELD_NAME: CopyOutStateMachineInputKeys =
-  "retainCopyReport";
-
-export const RETAIN_COPY_CSV_FIELD_NAME: CopyOutStateMachineInputKeys =
-  "retainCopyCsv";
+// Default file names used when the corresponding input override is not supplied.
+export const DEFAULT_INSTRUCTIONS_KEY = "INSTRUCTIONS.jsonl";
+export const DEFAULT_START_MARKER_KEY = "STARTED_COPY.txt";
+export const DEFAULT_SUMMARY_CSV_KEY = "ENDED_COPY.csv";
+export const DEFAULT_HTML_REPORT_KEY = "ENDED_COPY_REPORT.html";
 
 /**
  * Common fields shared by all bucket definitions.


### PR DESCRIPTION
### Changes
* Adds a `retainCopyCsv` option which copies the ENDED_CSV to the working bucket after the copy is complete.
* I've changed the output of the summarise copy lambda to the CSV/HTML locations, rather than the CSV output itself. This prevents the step functions output limit from being exceeded. E.g. now the output looks something like:

```json
{                                                                                                                                                                                                                                                                                                                 
    "destinationBucket": "bucket",          
    "workingBucket": "working-bucket",       
    "csvKey": "<prefix>/ENDED_COPY.csv",                                                                                                                                                                                                                                                                 
    "htmlKey": "<prefix>/ENDED_COPY_REPORT.html",
    "workingCsvKey": "<prefix>/ENDED_COPY.csv",                                                                                                                                                                                                                                                              
    "workingHtmlKey": "<prefix>/ENDED_COPY_REPORT.html"                                                                                                                                                                                                                                                      
}  
```

* Added to the realistic test case to include tests for `retainCopyCsv` and `retainCopyReport`.    