### PR TITLE
feat: upgrade copyrite to v0.4.0

### DIFF
--- a/packages/steps-s3-copy/docker/copy-batch-docker-image/Dockerfile
+++ b/packages/steps-s3-copy/docker/copy-batch-docker-image/Dockerfile
@@ -19,7 +19,7 @@ RUN go build copy-batch-fargate.go ecs-heartbeat.go copy-runner.go constants.go 
 # the tag removes some legacy Go 1.x support from the AWS lambda library
 RUN go build -tags lambda.norpc copy-batch-lambda.go copy-runner.go constants.go types.go utils.go
 
-ADD https://github.com/umccr/copyrite/releases/download/v0.3.2/copyrite-aarch64-unknown-linux-gnu.tar.gz .
+ADD https://github.com/umccr/copyrite/releases/download/v0.4.0/copyrite-aarch64-unknown-linux-gnu.tar.gz .
 
 RUN gzip -dc copyrite-aarch64-unknown-linux-gnu.tar.gz | tar xf -
 


### PR DESCRIPTION
Related to https://github.com/umccr/copyrite/pull/75

This fixes the stalled stream protection error that occurs with large files here.