### PR TITLE
Bumped to copyrite 0.6.0 to fix bug with ceph destination

### DIFF
--- a/packages/steps-s3-copy/docker/copy-batch-docker-image/Dockerfile
+++ b/packages/steps-s3-copy/docker/copy-batch-docker-image/Dockerfile
@@ -1,5 +1,5 @@
 ARG TARGETARCH
-ARG COPYRITE_VERSION=v0.5.1
+ARG COPYRITE_VERSION=v0.6.0
 
 FROM public.ecr.aws/docker/library/golang:1.24.1-alpine AS builder
 

--- a/packages/steps-s3-copy/src/steps-s3-copy-construct.ts
+++ b/packages/steps-s3-copy/src/steps-s3-copy-construct.ts
@@ -30,7 +30,7 @@ import {
   StepsS3CopyInvokeSettings,
   stateInput,
 } from "./steps-s3-copy-input";
-import { Duration, Stack } from "aws-cdk-lib";
+import { Aws, Duration, Stack } from "aws-cdk-lib";
 import { ValidateThawParamsLambdaStepConstruct } from "./lib/validate-thaw-params-lambda-step-construct";
 import { CanWriteLambdaStepConstruct } from "./lib/can-write-lambda-step-construct";
 import { PricingDataLambdaStepConstruct } from "./lib/fetch-pricing-data-lambda-step-construct";
@@ -562,6 +562,22 @@ export class StepsS3CopyConstruct extends Construct {
         effect: Effect.ALLOW,
         actions: ["secretsmanager:GetSecretValue"],
         resources: ["*"],
+      }),
+    );
+
+    // we want to allow cross-account secret usage - which means we also need to give perms for
+    // secret manager to make KMS decrypt calls
+    writerRole.addToPolicy(
+      new PolicyStatement({
+        sid: "AllowCrossAccountDecryptViaSecretsManager",
+        effect: Effect.ALLOW,
+        actions: ["kms:Decrypt"],
+        resources: ["*"],
+        conditions: {
+          StringEquals: {
+            "kms:ViaService": `secretsmanager.${Aws.REGION}.amazonaws.com`,
+          },
+        },
       }),
     );
 


### PR DESCRIPTION
Use new copyrite
Also add KMS decrypt to enable cross account secret usage
