### PR TITLE
Fix/pricing api throttling

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -52,6 +52,7 @@
         "@aws-sdk/client-secrets-manager": "^3.1035.0",
         "@aws-sdk/lib-storage": "^3.1035.0",
         "csv-stringify": "^6.7.0",
+        "p-throttle": "^8.0.0",
         "tmp": "^0.2.5",
       },
       "devDependencies": {
@@ -547,6 +548,8 @@
     "p-limit": ["p-limit@7.3.0", "", { "dependencies": { "yocto-queue": "^1.2.1" } }, "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw=="],
 
     "p-queue": ["p-queue@6.6.2", "", { "dependencies": { "eventemitter3": "^4.0.4", "p-timeout": "^3.2.0" } }, "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ=="],
+
+    "p-throttle": ["p-throttle@8.1.0", "", {}, "sha512-c1wmXavsHZIC4g1OLhOsafK6jZSAeMo0Ap3yivj59PUcCkpacy5YgWdgIp/dB4vp1JZrfBSsPCR0YuADB+ENLQ=="],
 
     "p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg=="],
 

--- a/dev-testsuite/README.md
+++ b/dev-testsuite/README.md
@@ -91,3 +91,19 @@ The cost estimation models can be tested directly using a set of copy scenarios 
 ```bash
 bun test-cost-estimation
 ```
+
+To avoid hitting AWS Pricing rate limits, we applies a small client-side throttle and retry/backoff when fetching pricing data (see `packages/steps-s3-copy/lambda/common/cost-estimation.ts`):
+
+```ts
+const pricingThrottle = pThrottle({ limit: 5, interval: 1000 });
+
+const PRICING_MAX_RETRIES = 5;
+const PRICING_RETRY_BASE_DELAY_MS = 200;
+const PRICING_RETRY_MAX_DELAY_MS = 5000;
+```
+
+The `pricing-api-fetch-throttling` script repeatedly runs the pricing fetches to exercise that throttle and the retry logic. The number of runs is controlled by the `REPEATS` variable inside the script. Per-run summaries print to stdout; retry and error diagnostics are written to stderr so you can inspect throttling activity separately.
+
+```bash
+bun pricing-api-fetch-throttling
+```

--- a/dev-testsuite/README.md
+++ b/dev-testsuite/README.md
@@ -92,7 +92,7 @@ The cost estimation models can be tested directly using a set of copy scenarios 
 bun test-cost-estimation
 ```
 
-To avoid hitting AWS Pricing rate limits, we applies a small client-side throttle and retry/backoff when fetching pricing data (see `packages/steps-s3-copy/lambda/common/cost-estimation.ts`):
+To avoid hitting AWS Pricing rate limits, we apply a small client-side throttle and retry/backoff when fetching pricing data (see `packages/steps-s3-copy/lambda/common/cost-estimation.ts`):
 
 ```ts
 const pricingThrottle = pThrottle({ limit: 5, interval: 1000 });

--- a/dev-testsuite/package.json
+++ b/dev-testsuite/package.json
@@ -16,7 +16,8 @@
     "step-head-objects": "bun test ./test-step-head-objects-lambda.ts",
     "report-preview": "bun test ./test-report-preview.ts",
     "report-preview-dryrun": "bun test ./test-report-preview.ts --dry-run",
-    "cost-estimation": "bun test ./test-cost-estimation.ts"
+    "cost-estimation": "bun test ./test-cost-estimation.ts",
+    "pricing-api-fetch-throttling": "bun test ./test-pricing-api-fetch-throttling.ts"
   },
   "dependencies": {
     "@aws-sdk/client-cloudformation": "^3.1035.0",

--- a/dev-testsuite/test-pricing-api-fetch-throttling.ts
+++ b/dev-testsuite/test-pricing-api-fetch-throttling.ts
@@ -5,7 +5,7 @@ import {
 } from "../packages/steps-s3-copy/lambda/common/cost-estimation";
 
 // number of simulated lambdas to run
-const REPEATS = 5;
+const REPEATS = 100;
 
 // Launch all `REPEATS` runs at the same time and wait for them to finish.
 const tasks = Array.from({ length: REPEATS }, () =>

--- a/dev-testsuite/test-pricing-api-fetch-throttling.ts
+++ b/dev-testsuite/test-pricing-api-fetch-throttling.ts
@@ -1,0 +1,42 @@
+import {
+  fetchColdStorageRetrievalCosts,
+  fetchCrossRegionCosts,
+  fetchComputeCosts,
+} from "../packages/steps-s3-copy/lambda/common/cost-estimation";
+
+// number of simulated lambdas to run
+const REPEATS = 5;
+
+// Launch all `REPEATS` runs at the same time and wait for them to finish.
+const tasks = Array.from({ length: REPEATS }, () =>
+  Promise.all([
+    fetchColdStorageRetrievalCosts("ap-southeast-2"),
+    fetchCrossRegionCosts("ap-southeast-2"),
+    fetchComputeCosts("ap-southeast-2"),
+  ]),
+);
+
+const results = await Promise.all(tasks);
+// check if the fetched data is non-empty --> means the API calls were successful
+const isNonEmpty = (v: any) => {
+  if (v == null) return false;
+  if (Array.isArray(v)) return v.length > 0;
+  if (typeof v === "object") return Object.keys(v).length > 0;
+  return true;
+};
+
+results.forEach(([cold, cross, compute], idx) => {
+  const cold_ok = isNonEmpty(cold);
+  const cross_ok = isNonEmpty(cross);
+  const compute_ok = isNonEmpty(compute.lambda);
+  // Some colors for the console output to make it easier to see which runs succeeded and which failed.
+  const COLORS = { green: "\x1b[32m", red: "\x1b[31m", reset: "\x1b[0m" };
+  const okSym = (v: boolean) =>
+    v ? `${COLORS.green}✔${COLORS.reset}` : `${COLORS.red}✖${COLORS.reset}`;
+
+  console.log(
+    `run ${idx + 1}: cold=${okSym(cold_ok)} cross=${okSym(
+      cross_ok,
+    )} compute=${okSym(compute_ok)}`,
+  );
+});

--- a/dev-testsuite/test-pricing-api-fetch-throttling.ts
+++ b/dev-testsuite/test-pricing-api-fetch-throttling.ts
@@ -25,18 +25,18 @@ const isNonEmpty = (v: any) => {
   return true;
 };
 
+const COLORS = { green: "\x1b[32m", red: "\x1b[31m", reset: "\x1b[0m" };
+const okSym = (v: boolean) =>
+  v ? `${COLORS.green}✔${COLORS.reset}` : `${COLORS.red}✖${COLORS.reset}`;
+
 results.forEach(([cold, cross, compute], idx) => {
-  const cold_ok = isNonEmpty(cold);
-  const cross_ok = isNonEmpty(cross);
-  const compute_ok = isNonEmpty(compute.lambda);
-  // Some colors for the console output to make it easier to see which runs succeeded and which failed.
-  const COLORS = { green: "\x1b[32m", red: "\x1b[31m", reset: "\x1b[0m" };
-  const okSym = (v: boolean) =>
-    v ? `${COLORS.green}✔${COLORS.reset}` : `${COLORS.red}✖${COLORS.reset}`;
+  const coldOk = isNonEmpty(cold);
+  const crossOk = isNonEmpty(cross);
+  const computeOk = isNonEmpty(compute.lambda);
 
   console.log(
-    `run ${idx + 1}: cold=${okSym(cold_ok)} cross=${okSym(
-      cross_ok,
-    )} compute=${okSym(compute_ok)}`,
+    `run ${idx + 1}: cold=${okSym(coldOk)} cross=${okSym(
+      crossOk,
+    )} compute=${okSym(computeOk)}`,
   );
 });

--- a/packages/steps-s3-copy/lambda/common/cost-estimation.ts
+++ b/packages/steps-s3-copy/lambda/common/cost-estimation.ts
@@ -6,6 +6,7 @@ import {
   GetProductsCommandOutput,
   FilterType,
 } from "@aws-sdk/client-pricing";
+
 import pThrottle from "p-throttle";
 
 import {
@@ -44,55 +45,23 @@ const pricingThrottle = pThrottle({
   interval: 1000,
 });
 
-// Retry constants — up to 5 retries, exponential backoff (200ms base, 5s cap).
-const PRICING_MAX_RETRIES = 5;
-const PRICING_RETRY_BASE_DELAY_MS = 200;
-const PRICING_RETRY_MAX_DELAY_MS = 5000;
+// Retry constants:  total SDK attempts (1initial + 5 retries).
+const PRICING_MAX_ATTEMPTS = 6;
 
-// Pauses execution between retry attempts.
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+// Retry/backoff is handled by the AWS SDK. We configure the SDK clients
+// below using `maxAttempts` + `retryMode` to control retry behaviour.
 
-// Returns true only for throttling/rate-limit errors worth retrying.
-function isRetryablePricingError(error: unknown): boolean {
-  const maybeError = error as {
-    name?: string;
-    message?: string;
-    code?: string;
-    Code?: string;
-    $metadata?: { httpStatusCode?: number };
-  };
-
-  const errorName = maybeError.name ?? maybeError.code ?? maybeError.Code;
-  const statusCode = maybeError.$metadata?.httpStatusCode;
-
-  if (statusCode === 429) {
-    return true;
-  }
-
-  if (
-    errorName === "Throttling" ||
-    errorName === "ThrottlingException" ||
-    errorName === "TooManyRequestsException" ||
-    errorName === "RequestLimitExceeded" ||
-    errorName === "ProvisionedThroughputExceededException"
-  ) {
-    return true;
-  }
-
-  return /throttl|rate exceeded/i.test(maybeError.message ?? "");
-}
-
-// Exponential delay (200 * 2^attempt, capped at 5s) with jitter to avoid thundering herd.
-function getBackoffDelayWithJitterMs(attempt: number): number {
-  const exponentialDelay = Math.min(
-    PRICING_RETRY_MAX_DELAY_MS,
-    PRICING_RETRY_BASE_DELAY_MS * 2 ** attempt,
-  );
-
-  return Math.floor(Math.random() * exponentialDelay);
+// Helper to create a configured PricingClient
+function createPricingClient(): PricingClient {
+  return new PricingClient({
+    region: "us-east-1",
+    maxAttempts: PRICING_MAX_ATTEMPTS,
+    retryMode: "standard",
+  });
 }
 
 // Wraps GetProducts with the throttle gate (max 5/sec).
+// `hrottledGetProducts already applies the throttle and the SDK handles retries.
 const throttledGetProducts = pricingThrottle(
   async (
     client: PricingClient,
@@ -100,33 +69,6 @@ const throttledGetProducts = pricingThrottle(
   ): Promise<GetProductsCommandOutput> =>
     client.send(new GetProductsCommand(input)),
 );
-
-// Calls throttledGetProducts and retries on throttling errors with exponential backoff.
-async function throttledGetProductsWithRetry(
-  client: PricingClient,
-  input: GetProductsCommandInput,
-): Promise<GetProductsCommandOutput> {
-  for (let attempt = 0; attempt <= PRICING_MAX_RETRIES; attempt++) {
-    try {
-      return await throttledGetProducts(client, input);
-    } catch (error) {
-      const isLastAttempt = attempt === PRICING_MAX_RETRIES;
-      if (!isRetryablePricingError(error) || isLastAttempt) {
-        throw error;
-      }
-
-      const delayMs = getBackoffDelayWithJitterMs(attempt);
-      console.warn(
-        `[Pricing Retry] GetProducts throttled (attempt ${attempt + 1}/${
-          PRICING_MAX_RETRIES + 1
-        }). Retrying in ${delayMs} ms.`,
-      );
-      await sleep(delayMs);
-    }
-  }
-
-  throw new Error("Unexpected retry flow in throttledGetProductsWithRetry");
-}
 
 // --------------------------------------------------------------------------------------------
 // Thawing cost estimation (returns 0 for non-cold storage classes)
@@ -151,7 +93,7 @@ export type ColdStorageRetrievalCosts = {
 export async function fetchColdStorageRetrievalCosts(
   region: string,
 ): Promise<ColdStorageRetrievalCosts> {
-  const client = new PricingClient({ region: "us-east-1" });
+  const client = createPricingClient();
 
   const fetchAllPrices = async (
     allFilters: { Field: string; Value: string }[][],
@@ -178,7 +120,7 @@ export async function fetchColdStorageRetrievalCosts(
       ],
       MaxResults: 1,
     });
-    const response = await throttledGetProductsWithRetry(client, command.input);
+    const response = await throttledGetProducts(client, command.input);
     if (!response.PriceList?.length) return 0;
     const priceItem = JSON.parse(response.PriceList[0] as string);
     const priceDimensions = Object.values(
@@ -393,8 +335,8 @@ interface EgressPriceTier {
 export async function fetchCrossRegionEgressPrice(
   fromRegion: string,
 ): Promise<EgressPriceTier[]> {
-  const client = new PricingClient({ region: "us-east-1" });
-  const response = await throttledGetProductsWithRetry(client, {
+  const client = createPricingClient();
+  const response = await throttledGetProducts(client, {
     ServiceCode: "AWSDataTransfer",
     Filters: [
       {
@@ -438,8 +380,8 @@ export async function fetchCrossRegionEgressPrice(
 export async function fetchCrossRegionPutRequestPrice(
   fromRegion: string,
 ): Promise<number> {
-  const client = new PricingClient({ region: "us-east-1" });
-  const response = await throttledGetProductsWithRetry(client, {
+  const client = createPricingClient();
+  const response = await throttledGetProducts(client, {
     ServiceCode: "AmazonS3",
     Filters: [
       { Type: FilterType.TERM_MATCH, Field: "regionCode", Value: fromRegion },
@@ -565,10 +507,10 @@ const regionPrefixMap: Record<string, string> = {
 async function fetchLambdaComputePrice(
   region: string,
 ): Promise<Pick<ComputeCosts, "lambda">> {
-  const client = new PricingClient({ region: "us-east-1" });
+  const client = createPricingClient();
 
   const [durationResponse, invocationResponse] = await Promise.all([
-    throttledGetProductsWithRetry(client, {
+    throttledGetProducts(client, {
       ServiceCode: "AWSLambda",
       Filters: [
         { Type: FilterType.TERM_MATCH, Field: "regionCode", Value: region },
@@ -580,7 +522,7 @@ async function fetchLambdaComputePrice(
       ],
       MaxResults: 1,
     }),
-    throttledGetProductsWithRetry(client, {
+    throttledGetProducts(client, {
       ServiceCode: "AWSLambda",
       Filters: [
         { Type: FilterType.TERM_MATCH, Field: "regionCode", Value: region },
@@ -620,7 +562,7 @@ async function fetchLambdaComputePrice(
 async function fetchFargateComputePrice(
   region: string,
 ): Promise<Pick<ComputeCosts, "fargate">> {
-  const client = new PricingClient({ region: "us-east-1" });
+  const client = createPricingClient();
 
   const regionPrefix = regionPrefixMap[region];
 
@@ -629,7 +571,7 @@ async function fetchFargateComputePrice(
   }
 
   const [vcpuResponse, memResponse] = await Promise.all([
-    throttledGetProductsWithRetry(client, {
+    throttledGetProducts(client, {
       ServiceCode: "AmazonECS",
       Filters: [
         { Type: FilterType.TERM_MATCH, Field: "regionCode", Value: region },
@@ -641,7 +583,7 @@ async function fetchFargateComputePrice(
       ],
       MaxResults: 1,
     }),
-    throttledGetProductsWithRetry(client, {
+    throttledGetProducts(client, {
       ServiceCode: "AmazonECS",
       Filters: [
         { Type: FilterType.TERM_MATCH, Field: "regionCode", Value: region },

--- a/packages/steps-s3-copy/lambda/common/cost-estimation.ts
+++ b/packages/steps-s3-copy/lambda/common/cost-estimation.ts
@@ -38,20 +38,21 @@ export interface PricingData {
   computeCosts: ComputeCosts;
   fetchedAt: string;
 }
-// Throttling for AWS Pricing API requests (max 5 requests per second)
+// Rate limiter — queues Pricing API calls to max 5 per second to prevent burst rejections.
 const pricingThrottle = pThrottle({
   limit: 5,
   interval: 1000,
 });
 
-// Retry logic constants for AWS Pricing API requests:
-//  (max 5 retries, exponential backoff with jitter)
+// Retry constants — up to 5 retries, exponential backoff (200ms base, 5s cap).
 const PRICING_MAX_RETRIES = 5;
 const PRICING_RETRY_BASE_DELAY_MS = 200;
 const PRICING_RETRY_MAX_DELAY_MS = 5000;
 
+// Pauses execution between retry attempts.
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+// Returns true only for throttling/rate-limit errors worth retrying.
 function isRetryablePricingError(error: unknown): boolean {
   const maybeError = error as {
     name?: string;
@@ -81,6 +82,7 @@ function isRetryablePricingError(error: unknown): boolean {
   return /throttl|rate exceeded/i.test(maybeError.message ?? "");
 }
 
+// Exponential delay (200 * 2^attempt, capped at 5s) with jitter to avoid thundering herd.
 function getBackoffDelayWithJitterMs(attempt: number): number {
   const exponentialDelay = Math.min(
     PRICING_RETRY_MAX_DELAY_MS,
@@ -90,6 +92,7 @@ function getBackoffDelayWithJitterMs(attempt: number): number {
   return Math.floor(Math.random() * exponentialDelay);
 }
 
+// Wraps GetProducts with the throttle gate (max 5/sec).
 const throttledGetProducts = pricingThrottle(
   async (
     client: PricingClient,
@@ -98,6 +101,7 @@ const throttledGetProducts = pricingThrottle(
     client.send(new GetProductsCommand(input)),
 );
 
+// Calls throttledGetProducts and retries on throttling errors with exponential backoff.
 async function throttledGetProductsWithRetry(
   client: PricingClient,
   input: GetProductsCommandInput,

--- a/packages/steps-s3-copy/lambda/common/cost-estimation.ts
+++ b/packages/steps-s3-copy/lambda/common/cost-estimation.ts
@@ -2,8 +2,11 @@ import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import {
   PricingClient,
   GetProductsCommand,
+  GetProductsCommandInput,
+  GetProductsCommandOutput,
   FilterType,
 } from "@aws-sdk/client-pricing";
+import pThrottle from "p-throttle";
 
 import {
   bytesToGB,
@@ -35,6 +38,91 @@ export interface PricingData {
   computeCosts: ComputeCosts;
   fetchedAt: string;
 }
+// Throttling for AWS Pricing API requests (max 5 requests per second)
+const pricingThrottle = pThrottle({
+  limit: 5,
+  interval: 1000,
+});
+
+// Retry logic constants for AWS Pricing API requests:
+//  (max 5 retries, exponential backoff with jitter)
+const PRICING_MAX_RETRIES = 5;
+const PRICING_RETRY_BASE_DELAY_MS = 200;
+const PRICING_RETRY_MAX_DELAY_MS = 5000;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function isRetryablePricingError(error: unknown): boolean {
+  const maybeError = error as {
+    name?: string;
+    message?: string;
+    code?: string;
+    Code?: string;
+    $metadata?: { httpStatusCode?: number };
+  };
+
+  const errorName = maybeError.name ?? maybeError.code ?? maybeError.Code;
+  const statusCode = maybeError.$metadata?.httpStatusCode;
+
+  if (statusCode === 429) {
+    return true;
+  }
+
+  if (
+    errorName === "Throttling" ||
+    errorName === "ThrottlingException" ||
+    errorName === "TooManyRequestsException" ||
+    errorName === "RequestLimitExceeded" ||
+    errorName === "ProvisionedThroughputExceededException"
+  ) {
+    return true;
+  }
+
+  return /throttl|rate exceeded/i.test(maybeError.message ?? "");
+}
+
+function getBackoffDelayWithJitterMs(attempt: number): number {
+  const exponentialDelay = Math.min(
+    PRICING_RETRY_MAX_DELAY_MS,
+    PRICING_RETRY_BASE_DELAY_MS * 2 ** attempt,
+  );
+
+  return Math.floor(Math.random() * exponentialDelay);
+}
+
+const throttledGetProducts = pricingThrottle(
+  async (
+    client: PricingClient,
+    input: GetProductsCommandInput,
+  ): Promise<GetProductsCommandOutput> =>
+    client.send(new GetProductsCommand(input)),
+);
+
+async function throttledGetProductsWithRetry(
+  client: PricingClient,
+  input: GetProductsCommandInput,
+): Promise<GetProductsCommandOutput> {
+  for (let attempt = 0; attempt <= PRICING_MAX_RETRIES; attempt++) {
+    try {
+      return await throttledGetProducts(client, input);
+    } catch (error) {
+      const isLastAttempt = attempt === PRICING_MAX_RETRIES;
+      if (!isRetryablePricingError(error) || isLastAttempt) {
+        throw error;
+      }
+
+      const delayMs = getBackoffDelayWithJitterMs(attempt);
+      console.warn(
+        `[Pricing Retry] GetProducts throttled (attempt ${attempt + 1}/${
+          PRICING_MAX_RETRIES + 1
+        }). Retrying in ${delayMs} ms.`,
+      );
+      await sleep(delayMs);
+    }
+  }
+
+  throw new Error("Unexpected retry flow in throttledGetProductsWithRetry");
+}
 
 // --------------------------------------------------------------------------------------------
 // Thawing cost estimation (returns 0 for non-cold storage classes)
@@ -61,16 +149,12 @@ export async function fetchColdStorageRetrievalCosts(
 ): Promise<ColdStorageRetrievalCosts> {
   const client = new PricingClient({ region: "us-east-1" });
 
-  const sleep = (ms: number) =>
-    new Promise((resolve) => setTimeout(resolve, ms));
-
   const fetchAllPrices = async (
     allFilters: { Field: string; Value: string }[][],
   ) => {
     const results: number[] = [];
     for (const filters of allFilters) {
       results.push(await fetchPrice(filters));
-      await sleep(200);
     }
     return results;
   };
@@ -90,7 +174,7 @@ export async function fetchColdStorageRetrievalCosts(
       ],
       MaxResults: 1,
     });
-    const response = await client.send(command);
+    const response = await throttledGetProductsWithRetry(client, command.input);
     if (!response.PriceList?.length) return 0;
     const priceItem = JSON.parse(response.PriceList[0] as string);
     const priceDimensions = Object.values(
@@ -306,7 +390,7 @@ export async function fetchCrossRegionEgressPrice(
   fromRegion: string,
 ): Promise<EgressPriceTier[]> {
   const client = new PricingClient({ region: "us-east-1" });
-  const command = new GetProductsCommand({
+  const response = await throttledGetProductsWithRetry(client, {
     ServiceCode: "AWSDataTransfer",
     Filters: [
       {
@@ -322,8 +406,6 @@ export async function fetchCrossRegionEgressPrice(
     ],
     MaxResults: 1,
   });
-
-  const response = await client.send(command);
   if (!response.PriceList?.length) return [];
 
   const priceItem = JSON.parse(response.PriceList[0] as string);
@@ -353,7 +435,7 @@ export async function fetchCrossRegionPutRequestPrice(
   fromRegion: string,
 ): Promise<number> {
   const client = new PricingClient({ region: "us-east-1" });
-  const command = new GetProductsCommand({
+  const response = await throttledGetProductsWithRetry(client, {
     ServiceCode: "AmazonS3",
     Filters: [
       { Type: FilterType.TERM_MATCH, Field: "regionCode", Value: fromRegion },
@@ -361,8 +443,6 @@ export async function fetchCrossRegionPutRequestPrice(
     ],
     MaxResults: 1,
   });
-
-  const response = await client.send(command);
   if (!response.PriceList?.length) return 0;
 
   const priceItem = JSON.parse(response.PriceList[0] as string);
@@ -484,34 +564,30 @@ async function fetchLambdaComputePrice(
   const client = new PricingClient({ region: "us-east-1" });
 
   const [durationResponse, invocationResponse] = await Promise.all([
-    client.send(
-      new GetProductsCommand({
-        ServiceCode: "AWSLambda",
-        Filters: [
-          { Type: FilterType.TERM_MATCH, Field: "regionCode", Value: region },
-          {
-            Type: FilterType.TERM_MATCH,
-            Field: "group",
-            Value: "AWS-Lambda-Duration",
-          },
-        ],
-        MaxResults: 1,
-      }),
-    ),
-    client.send(
-      new GetProductsCommand({
-        ServiceCode: "AWSLambda",
-        Filters: [
-          { Type: FilterType.TERM_MATCH, Field: "regionCode", Value: region },
-          {
-            Type: FilterType.TERM_MATCH,
-            Field: "group",
-            Value: "AWS-Lambda-Requests",
-          },
-        ],
-        MaxResults: 1,
-      }),
-    ),
+    throttledGetProductsWithRetry(client, {
+      ServiceCode: "AWSLambda",
+      Filters: [
+        { Type: FilterType.TERM_MATCH, Field: "regionCode", Value: region },
+        {
+          Type: FilterType.TERM_MATCH,
+          Field: "group",
+          Value: "AWS-Lambda-Duration",
+        },
+      ],
+      MaxResults: 1,
+    }),
+    throttledGetProductsWithRetry(client, {
+      ServiceCode: "AWSLambda",
+      Filters: [
+        { Type: FilterType.TERM_MATCH, Field: "regionCode", Value: region },
+        {
+          Type: FilterType.TERM_MATCH,
+          Field: "group",
+          Value: "AWS-Lambda-Requests",
+        },
+      ],
+      MaxResults: 1,
+    }),
   ]);
 
   const durationItem = JSON.parse(durationResponse.PriceList![0] as string);
@@ -549,34 +625,30 @@ async function fetchFargateComputePrice(
   }
 
   const [vcpuResponse, memResponse] = await Promise.all([
-    client.send(
-      new GetProductsCommand({
-        ServiceCode: "AmazonECS",
-        Filters: [
-          { Type: FilterType.TERM_MATCH, Field: "regionCode", Value: region },
-          {
-            Type: FilterType.TERM_MATCH,
-            Field: "usagetype",
-            Value: `${regionPrefix}-Fargate-vCPU-Hours:perCPU`,
-          },
-        ],
-        MaxResults: 1,
-      }),
-    ),
-    client.send(
-      new GetProductsCommand({
-        ServiceCode: "AmazonECS",
-        Filters: [
-          { Type: FilterType.TERM_MATCH, Field: "regionCode", Value: region },
-          {
-            Type: FilterType.TERM_MATCH,
-            Field: "usagetype",
-            Value: `${regionPrefix}-Fargate-GB-Hours`,
-          },
-        ],
-        MaxResults: 1,
-      }),
-    ),
+    throttledGetProductsWithRetry(client, {
+      ServiceCode: "AmazonECS",
+      Filters: [
+        { Type: FilterType.TERM_MATCH, Field: "regionCode", Value: region },
+        {
+          Type: FilterType.TERM_MATCH,
+          Field: "usagetype",
+          Value: `${regionPrefix}-Fargate-vCPU-Hours:perCPU`,
+        },
+      ],
+      MaxResults: 1,
+    }),
+    throttledGetProductsWithRetry(client, {
+      ServiceCode: "AmazonECS",
+      Filters: [
+        { Type: FilterType.TERM_MATCH, Field: "regionCode", Value: region },
+        {
+          Type: FilterType.TERM_MATCH,
+          Field: "usagetype",
+          Value: `${regionPrefix}-Fargate-GB-Hours`,
+        },
+      ],
+      MaxResults: 1,
+    }),
   ]);
 
   const vcpuItem = JSON.parse(vcpuResponse.PriceList![0] as string);

--- a/packages/steps-s3-copy/package.json
+++ b/packages/steps-s3-copy/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/lib-storage": "^3.1035.0",
     "@aws-sdk/client-pricing": "^3.1045.0",
     "csv-stringify": "^6.7.0",
+    "p-throttle": "^8.0.0",
     "tmp": "^0.2.5"
   },
   "bundledDependencies": [
@@ -55,6 +56,7 @@
     "@aws-sdk/lib-storage",
     "@aws-sdk/client-pricing",
     "csv-stringify",
+    "p-throttle",
     "tmp"
   ],
   "devDependencies": {


### PR DESCRIPTION
This PR addresses issue #69.

It adds a small client-side throttle (p-throttle) and jittered exponential backoff retries around AWS Pricing GetProducts calls to prevent bursty requests and avoid the `ThrottlingException` error.

It also includes a short dev test (`pricing-api-fetch-throttling`) and README(dev) notes on how to run it. I am not sure whether we should keep this test here, as it might be too specific ... so I am happy to just remove it if preferred.

I ran this test simulating up to 100 API fetches (`const REPEATS = 100`) under the defaults params defined in the `cost-estimation.ts` :

```
const pricingThrottle = pThrottle({
  limit: 5,
  interval: 1000,
});

const PRICING_MAX_RETRIES = 5;
const PRICING_RETRY_BASE_DELAY_MS = 200;
const PRICING_RETRY_MAX_DELAY_MS = 5000;

```
and all the fetches succeeded.

I also experimented with other parameters (for example, allowing 100 simultaneous API calls instead of limiting to 5 as is now defined) and was able to reproduce the `ThrottlingException`.  So the guardrail is working as expected.



 


